### PR TITLE
Add connected screen presence tracking

### DIFF
--- a/clock/src/App.css
+++ b/clock/src/App.css
@@ -1,6 +1,7 @@
 body {
   /* prevent scrolling */
   /*overflow: hidden;*/
+  overflow-x: hidden;
 }
 
 html {

--- a/clock/src/App.spec.tsx
+++ b/clock/src/App.spec.tsx
@@ -187,12 +187,11 @@ describe("App", () => {
   });
 
   describe("State 1: unauthenticated, no listenPrefix", () => {
-    it("renders Controller and StateListener only", () => {
+    it("renders Controller only", () => {
       setupState1();
       render(<App />);
 
       expect(screen.getByTestId("controller")).toBeInTheDocument();
-      expect(screen.getByTestId("state-listener")).toBeInTheDocument();
     });
 
     it("does not render display screens", () => {

--- a/clock/src/App.tsx
+++ b/clock/src/App.tsx
@@ -20,7 +20,6 @@ import ScoreBoard from "./screens/ScoreBoard";
 import Idle from "./screens/Idle";
 
 import { VIEWS, Sports, getBackground } from "./constants";
-import StateListener from "./StateListener";
 import MatchController from "./match-controller/MatchController";
 import useGlobalShortcuts from "./hooks/useGlobalShortcuts";
 import useNightBlackout from "./hooks/useNightBlackout";
@@ -190,12 +189,7 @@ function App() {
 
   // State 1: no listenPrefix, not authenticated — Controller handles screen selector + login
   if (!listenPrefix && !isAuthenticated) {
-    return (
-      <div>
-        <Controller />
-        <StateListener />
-      </div>
-    );
+    return <Controller />;
   }
 
   // Show spinner while waiting for auth state or Firebase data to load
@@ -272,19 +266,13 @@ function App() {
         >
           Aftengja skjá
         </Button>
-        <StateListener />
       </div>
     );
   }
 
   // State 3: authenticated, no listenPrefix — show ONLY screen selector
   if (!listenPrefix) {
-    return (
-      <div>
-        <Controller />
-        <StateListener />
-      </div>
-    );
+    return <Controller />;
   }
 
   // State 4: authenticated + listenPrefix set — full UI with disconnect/logout buttons
@@ -381,7 +369,6 @@ function App() {
           Aftengjast skjá
         </Button>
       </ButtonGroup>
-      <StateListener />
     </div>
   );
 }

--- a/clock/src/App.tsx
+++ b/clock/src/App.tsx
@@ -24,6 +24,7 @@ import StateListener from "./StateListener";
 import MatchController from "./match-controller/MatchController";
 import useGlobalShortcuts from "./hooks/useGlobalShortcuts";
 import useNightBlackout from "./hooks/useNightBlackout";
+import useScreenPresence from "./hooks/useScreenPresence";
 import { useThemeCssVars, resolveTheme } from "./hooks/useThemeCssVars";
 import { shouldShowGoalCelebration } from "./utils/matchUtils";
 import baddi from "./images/baddi.gif";
@@ -173,6 +174,8 @@ function App() {
   );
 
   const isAuthenticated = auth.isLoaded && !auth.isEmpty;
+
+  useScreenPresence(isAuthenticated ? "" : listenPrefix);
 
   // Apply viewport fontSize to the root <html> element so all rem-based
   // content (clocks, scores, etc.) scales to the physical screen config.

--- a/clock/src/StateListener.css
+++ b/clock/src/StateListener.css
@@ -1,20 +1,16 @@
 .connect-indicator {
-  position: absolute;
-  top: 4px;
-  right: 8px;
   display: flex;
   align-items: center;
   gap: 4px;
-  z-index: 9999;
   font-family: sans-serif;
+  white-space: nowrap;
+  margin-left: auto;
 }
 
 .connect-indicator-count {
   font-size: 0.85rem;
   font-weight: bold;
-  color: #fff;
-  min-width: 1.2em;
-  text-align: center;
+  color: #333;
 }
 
 .connect-indicator-icon {

--- a/clock/src/StateListener.css
+++ b/clock/src/StateListener.css
@@ -3,8 +3,7 @@
   align-items: center;
   gap: 4px;
   font-family: sans-serif;
-  white-space: nowrap;
-  margin-left: auto;
+  flex-shrink: 0;
 }
 
 .connect-indicator-count {

--- a/clock/src/StateListener.css
+++ b/clock/src/StateListener.css
@@ -1,11 +1,25 @@
 .connect-indicator {
-  text-align: right;
   position: absolute;
-  top: 0;
-  right: 0;
-  color: green;
-  font-size: 2rem;
-  line-height: 1.5rem;
+  top: 4px;
+  right: 8px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  z-index: 9999;
+  font-family: sans-serif;
+}
+
+.connect-indicator-count {
+  font-size: 0.85rem;
+  font-weight: bold;
+  color: #fff;
+  min-width: 1.2em;
+  text-align: center;
+}
+
+.connect-indicator-icon {
+  font-size: 0.7rem;
+  color: #4caf50;
   animation: state-color 5s infinite;
 }
 

--- a/clock/src/StateListener.tsx
+++ b/clock/src/StateListener.tsx
@@ -1,14 +1,25 @@
 import { useLocalState } from "./contexts/LocalStateContext";
+import useConnectedScreens from "./hooks/useConnectedScreens";
 import "./StateListener.css";
 
 const StateListener = () => {
-  const { auth } = useLocalState();
+  const { auth, listenPrefix } = useLocalState();
   const isAuthenticated = auth.isLoaded && !auth.isEmpty;
+  const connectedCount = useConnectedScreens(
+    isAuthenticated ? listenPrefix : "",
+  );
 
-  if (isAuthenticated) {
-    return <div className="connect-indicator">&#8226;</div>;
-  }
-  return null;
+  if (!isAuthenticated || !listenPrefix) return null;
+
+  return (
+    <div
+      className="connect-indicator"
+      title={`${connectedCount} ${connectedCount === 1 ? "skjár tengdur" : "skjáir tengdir"}`}
+    >
+      <span className="connect-indicator-count">{connectedCount}</span>
+      <span className="connect-indicator-icon">&#9632;</span>
+    </div>
+  );
 };
 
 export default StateListener;

--- a/clock/src/controller/Controller.css
+++ b/clock/src/controller/Controller.css
@@ -16,6 +16,7 @@
 .controller .rs-nav {
   flex: 1;
   min-width: 0;
+  overflow: hidden;
 }
 
 .controller .nav-bar {
@@ -23,6 +24,14 @@
   align-items: center;
   width: 100%;
   gap: 8px;
+  overflow: hidden;
+}
+
+.controller .nav-bar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
 }
 
 .controller .control-item {

--- a/clock/src/controller/Controller.css
+++ b/clock/src/controller/Controller.css
@@ -13,17 +13,20 @@
   align-items: flex-start;
 }
 
-.controller .rs-nav {
+.controller .nav-bar {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
+}
+
+.controller .nav-bar-tabs {
   flex: 1;
   min-width: 0;
   overflow: hidden;
 }
 
-.controller .nav-bar {
-  display: flex;
-  align-items: center;
-  width: 100%;
-  gap: 8px;
+.controller .nav-bar-tabs .rs-nav {
   overflow: hidden;
 }
 
@@ -32,6 +35,7 @@
   align-items: center;
   gap: 8px;
   flex-shrink: 0;
+  padding-left: 8px;
 }
 
 .controller .control-item {

--- a/clock/src/controller/Controller.css
+++ b/clock/src/controller/Controller.css
@@ -238,6 +238,16 @@ input.longerInput {
   background-color: #2980d9;
 }
 
+.screen-selector-badge {
+  display: inline-block;
+  margin-left: 10px;
+  padding: 2px 8px;
+  font-size: 12px;
+  font-weight: bold;
+  background-color: rgba(255, 255, 255, 0.25);
+  border-radius: 10px;
+}
+
 .screen-selector-logout {
   padding: 10px 20px;
   font-size: 14px;

--- a/clock/src/controller/Controller.tsx
+++ b/clock/src/controller/Controller.tsx
@@ -9,6 +9,7 @@ import PeoplesIcon from "@rsuite/icons/Peoples";
 
 import { TABS, ASSET_VIEWS } from "../constants";
 import useConnectedScreens from "../hooks/useConnectedScreens";
+import StateListener from "../StateListener";
 
 const assetViewToTab: Record<string, string> = {
   [ASSET_VIEWS.teams]: TABS.teams,
@@ -318,6 +319,7 @@ const Controller = () => {
         >
           Stillingar
         </IconButton>
+        <StateListener />
       </div>
       {tab === TABS.media && <MediaManager />}
       {(tab === TABS.queue || tab === TABS.teams) && <AssetController />}

--- a/clock/src/controller/Controller.tsx
+++ b/clock/src/controller/Controller.tsx
@@ -310,16 +310,18 @@ const Controller = () => {
             Myndefni
           </Nav.Item>
         </Nav>
-        <IconButton
-          icon={<GearIcon />}
-          appearance="subtle"
-          size="sm"
-          onClick={() => setSettingsOpen(true)}
-          aria-label="Stillingar"
-        >
-          Stillingar
-        </IconButton>
-        <StateListener />
+        <div className="nav-bar-actions">
+          <IconButton
+            icon={<GearIcon />}
+            appearance="subtle"
+            size="sm"
+            onClick={() => setSettingsOpen(true)}
+            aria-label="Stillingar"
+          >
+            Stillingar
+          </IconButton>
+          <StateListener />
+        </div>
       </div>
       {tab === TABS.media && <MediaManager />}
       {(tab === TABS.queue || tab === TABS.teams) && <AssetController />}

--- a/clock/src/controller/Controller.tsx
+++ b/clock/src/controller/Controller.tsx
@@ -8,10 +8,35 @@ import ListIcon from "@rsuite/icons/List";
 import PeoplesIcon from "@rsuite/icons/Peoples";
 
 import { TABS, ASSET_VIEWS } from "../constants";
+import useConnectedScreens from "../hooks/useConnectedScreens";
 
 const assetViewToTab: Record<string, string> = {
   [ASSET_VIEWS.teams]: TABS.teams,
   [ASSET_VIEWS.assets]: TABS.queue,
+};
+
+const ScreenSelectorButton = ({
+  locationKey,
+  label,
+  onClick,
+}: {
+  locationKey: string;
+  label: string;
+  onClick: () => void;
+}) => {
+  const count = useConnectedScreens(locationKey);
+  return (
+    <button
+      key={locationKey}
+      className="screen-selector-button"
+      onClick={onClick}
+    >
+      {label}
+      {count > 0 && (
+        <span className="screen-selector-badge">{count} tengd</span>
+      )}
+    </button>
+  );
 };
 import { firebaseAuth } from "../firebaseAuth";
 import MatchActionSettings from "./MatchActionSettings";
@@ -213,13 +238,12 @@ const Controller = () => {
               const buttonLabel = `${label} ${screenNames}`;
 
               return (
-                <button
+                <ScreenSelectorButton
                   key={locationKey}
-                  className="screen-selector-button"
+                  locationKey={locationKey}
+                  label={buttonLabel}
                   onClick={() => setListenPrefix(locationKey)}
-                >
-                  {buttonLabel}
-                </button>
+                />
               );
             })}
           </div>

--- a/clock/src/controller/Controller.tsx
+++ b/clock/src/controller/Controller.tsx
@@ -299,17 +299,19 @@ const Controller = () => {
   return (
     <div className="controller">
       <div className="nav-bar">
-        <Nav appearance="tabs" onSelect={handleTabSelect} activeKey={tab}>
-          <Nav.Item eventKey={TABS.queue} icon={<ListIcon />}>
-            Biðröð
-          </Nav.Item>
-          <Nav.Item eventKey={TABS.teams} icon={<PeoplesIcon />}>
-            Lið
-          </Nav.Item>
-          <Nav.Item eventKey={TABS.media} icon={<MediaIcon />}>
-            Myndefni
-          </Nav.Item>
-        </Nav>
+        <div className="nav-bar-tabs">
+          <Nav appearance="tabs" onSelect={handleTabSelect} activeKey={tab}>
+            <Nav.Item eventKey={TABS.queue} icon={<ListIcon />}>
+              Biðröð
+            </Nav.Item>
+            <Nav.Item eventKey={TABS.teams} icon={<PeoplesIcon />}>
+              Lið
+            </Nav.Item>
+            <Nav.Item eventKey={TABS.media} icon={<MediaIcon />}>
+              Myndefni
+            </Nav.Item>
+          </Nav>
+        </div>
         <div className="nav-bar-actions">
           <IconButton
             icon={<GearIcon />}

--- a/clock/src/hooks/useConnectedScreens.ts
+++ b/clock/src/hooks/useConnectedScreens.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+import { ref, onValue } from "firebase/database";
+import { database } from "../firebase";
+
+/**
+ * Subscribes to `presence/{listenPrefix}` and returns the number of
+ * connected screens. Returns 0 when no listenPrefix is set.
+ */
+export default function useConnectedScreens(listenPrefix: string): number {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (!listenPrefix) return;
+
+    const presenceRef = ref(database, `presence/${listenPrefix}`);
+    const unsubscribe = onValue(presenceRef, (snap) => {
+      setCount(snap.exists() ? snap.size : 0);
+    });
+
+    return () => {
+      unsubscribe();
+      setCount(0);
+    };
+  }, [listenPrefix]);
+
+  return count;
+}

--- a/clock/src/hooks/useScreenPresence.ts
+++ b/clock/src/hooks/useScreenPresence.ts
@@ -1,0 +1,46 @@
+import { useEffect } from "react";
+import {
+  ref,
+  push,
+  set,
+  onDisconnect,
+  onValue,
+  serverTimestamp,
+} from "firebase/database";
+import { database } from "../firebase";
+
+/**
+ * Reports this screen's presence to Firebase at `presence/{listenPrefix}/{connectionId}`.
+ *
+ * Uses Firebase's `.info/connected` to detect connection state and
+ * `onDisconnect().remove()` to auto-cleanup on disconnect (clean or dirty).
+ *
+ * Should only be used by unauthenticated screen instances (not controllers).
+ */
+export default function useScreenPresence(listenPrefix: string): void {
+  useEffect(() => {
+    if (!listenPrefix) return;
+
+    const connectedRef = ref(database, ".info/connected");
+    let connectionRef: ReturnType<typeof push> | null = null;
+
+    const unsubscribe = onValue(connectedRef, (snap) => {
+      if (snap.val() !== true) return;
+
+      const presenceRef = ref(database, `presence/${listenPrefix}`);
+      connectionRef = push(presenceRef);
+
+      // Register cleanup BEFORE setting presence (avoids race condition)
+      void onDisconnect(connectionRef).remove();
+
+      void set(connectionRef, { connectedAt: serverTimestamp() });
+    });
+
+    return () => {
+      unsubscribe();
+      if (connectionRef) {
+        void set(connectionRef, null);
+      }
+    };
+  }, [listenPrefix]);
+}

--- a/clock/vite.config.ts
+++ b/clock/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     "process.env.PUBLIC_URL": JSON.stringify(""),
   },
   server: {
+    host: true,
     port: process.env.PORT ? parseInt(process.env.PORT, 10) : 3000,
     open: false,
     allowedHosts: true,

--- a/firebase-rules.json
+++ b/firebase-rules.json
@@ -26,6 +26,15 @@
         ".write": "root.child('auth').child(auth.uid).child($location).val() == true",
         ".read": true
       }
+    },
+    "presence": {
+      "$location": {
+        ".read": true,
+        "$connectionId": {
+          ".write": true,
+          ".validate": "newData.hasChildren(['connectedAt']) && newData.child('connectedAt').isNumber()"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Screens (unauthenticated clients) now report their presence to Firebase at `presence/{listenPrefix}/{connectionId}` using `.info/connected` + `onDisconnect().remove()` for automatic cleanup on disconnect/crash
- Controller screen selector shows a live connected count badge per screen
- Top-right indicator (previously a static green dot) now shows the number of screens connected to the active prefix

## Details

**Firebase rules** (`firebase-rules.json`): New `presence/$location/$connectionId` path allows unauthenticated writes, validated to only accept `{ connectedAt: <timestamp> }`. Readable by all.

**`useScreenPresence` hook**: Used by unauthenticated screen instances. Registers an `onDisconnect().remove()` handler before writing presence — following Firebase's race-condition-safe pattern. Cleans up immediately on unmount (e.g. "Aftengja skjá").

**`useConnectedScreens` hook**: Subscribes to `presence/{listenPrefix}` and returns child count. Used by controllers.

**Disconnect detection timing**: Clean disconnects (tab close, navigate away) are detected immediately. Dirty disconnects (crash, WiFi loss) take 2–5 minutes due to TCP socket timeout — this is a Firebase RTDB limitation with no workaround without heartbeats.

> **Note**: After merging, run `firebase deploy --only database` to deploy the updated rules to production.