### PR TITLE
Add countdown display and AM/PM time normalization

### DIFF
--- a/clock/AGENTS.md
+++ b/clock/AGENTS.md
@@ -474,6 +474,8 @@ mockedHook.mockReturnValue({ ... } as unknown as ReturnType<typeof useHook>);
 
 **Important**: Always run `pnpm format` after making changes. CI runs format checks and will fail if code is not properly formatted. To format only specific files: `pnpm exec prettier --write path/to/file.tsx`
 
+**Important**: Always run `pnpm lint` before pushing. CI runs ESLint and will fail on lint errors. Fix all errors in files you touched — do not add `eslint-disable` comments (see ESLint Policy above).
+
 ## Testing & Development
 
 ### Port Configuration

--- a/clock/src/App.tsx
+++ b/clock/src/App.tsx
@@ -11,6 +11,7 @@ import { useLocalState, useRemoteSettings } from "./contexts/LocalStateContext";
 import { firebaseAuth } from "./firebaseAuth";
 import Controller from "./controller/Controller";
 import MatchActions from "./controller/MatchActions";
+import MatchCountdownDisplay from "./controller/MatchCountdownDisplay";
 import RefreshHandler from "./controller/RefreshHandler";
 import AssetComponent from "./controller/asset/Asset";
 import PlaybackBar from "./controller/asset/queue/PlaybackBar";
@@ -338,6 +339,7 @@ function App() {
               asset && <ClearOverlayButton />
             )}
             {showMatchControls && <MatchActions />}
+            {showMatchControls && <MatchCountdownDisplay />}
           </div>
           <div className="controller-controls">
             <Controller />

--- a/clock/src/contexts/FirebaseStateContext.tsx
+++ b/clock/src/contexts/FirebaseStateContext.tsx
@@ -8,7 +8,6 @@ import React, {
   useRef,
   useMemo,
 } from "react";
-import moment from "moment";
 import { database, storageHelpers } from "../firebase";
 import {
   firebaseDatabase,
@@ -33,6 +32,7 @@ import {
   ClubOverride,
 } from "../types";
 import { Sports, DEFAULT_HALFSTOPS } from "../constants";
+import { msUntilMatchStart } from "../utils/timeUtils";
 import clubIds from "../club-ids";
 import assetTypes from "../controller/asset/AssetTypes";
 import {
@@ -810,7 +810,6 @@ export const FirebaseStateProvider: React.FC<FirebaseStateProviderProps> = ({
 
   const countdown = useCallback(() => {
     applyMatchUpdate((prev) => {
-      // Validate HH:mm format to prevent syncing invalid timestamp to Firebase
       if (
         !prev.matchStartTime ||
         typeof prev.matchStartTime !== "string" ||
@@ -821,21 +820,11 @@ export const FirebaseStateProvider: React.FC<FirebaseStateProviderProps> = ({
         );
         return prev;
       }
-      // Compute how far in the future the match starts using local time
-      // (Date.now / moment()), which reflects what the user sees in the UI.
-      // Then place "started" in the server-time coordinate system used by
-      // Clock.tsx (getServerTime()) so elapsed = getServerTime() - started
-      // gives the correct negative countdown value.
-      const localNow = moment();
-      const momentTime = moment(prev.matchStartTime, "HH:mm");
-      if (!momentTime.isValid()) {
+      const duration = msUntilMatchStart(prev.matchStartTime);
+      if (duration === null) {
         console.warn("countdown() invalid moment from matchStartTime");
         return prev;
       }
-      if (momentTime < localNow) {
-        momentTime.add(1, "days");
-      }
-      const duration = momentTime.valueOf() - localNow.valueOf();
       return {
         ...prev,
         started: getServerTime() + duration,

--- a/clock/src/controller/Controller.css
+++ b/clock/src/controller/Controller.css
@@ -410,3 +410,26 @@ input.longerInput {
   font-size: 12px;
   color: #888;
 }
+
+.match-countdown-display {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: #f0f4ff;
+  border: 1px solid #b8d0ff;
+  border-radius: 5px;
+}
+
+.match-countdown-label {
+  font-size: 13px;
+  color: #555;
+}
+
+.match-countdown-time {
+  font-size: 20px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: #1675e0;
+}

--- a/clock/src/controller/MatchActionSettings.tsx
+++ b/clock/src/controller/MatchActionSettings.tsx
@@ -3,6 +3,7 @@ import TeamSelector from "./TeamSelector";
 import HalfStops from "./HalfStops";
 import clubLogos from "../images/clubLogos";
 import { Sports, VIEWS, BACKGROUNDS } from "../constants";
+import { normalizeTimeTo24h } from "../utils/matchUtils";
 import {
   useMatch,
   useController,
@@ -57,6 +58,12 @@ const MatchActionSettings = () => {
               onChange={({ target: { value } }) =>
                 updateMatch({ matchStartTime: value })
               }
+              onBlur={({ target: { value } }) => {
+                const normalized = normalizeTimeTo24h(value);
+                if (normalized !== value) {
+                  updateMatch({ matchStartTime: normalized });
+                }
+              }}
             />
           </div>
           <div>

--- a/clock/src/controller/MatchCountdownDisplay.tsx
+++ b/clock/src/controller/MatchCountdownDisplay.tsx
@@ -1,17 +1,14 @@
 import { useState, useEffect } from "react";
-import moment from "moment";
+import { msUntilMatchStart, formatTime } from "../utils/timeUtils";
 import { useMatch } from "../contexts/FirebaseStateContext";
 
 const computeRemaining = (matchStartTime: string): string => {
-  const now = moment();
-  const target = moment(matchStartTime, "HH:mm");
-  if (!target.isValid()) return "";
-  if (target <= now) target.add(1, "days");
-  const diff = target.diff(now);
-  if (diff <= 0) return "00:00";
-  const minutes = Math.floor(diff / 60000);
-  const seconds = Math.floor((diff % 60000) / 1000);
-  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+  const ms = msUntilMatchStart(matchStartTime);
+  if (ms === null) return "";
+  if (ms <= 0) return formatTime(0, 0);
+  const minutes = Math.floor(ms / 60000);
+  const seconds = Math.floor((ms % 60000) / 1000);
+  return formatTime(minutes, seconds);
 };
 
 const MatchCountdownDisplay = () => {

--- a/clock/src/controller/MatchCountdownDisplay.tsx
+++ b/clock/src/controller/MatchCountdownDisplay.tsx
@@ -1,0 +1,54 @@
+import { useState, useEffect } from "react";
+import moment from "moment";
+import { useMatch } from "../contexts/FirebaseStateContext";
+
+const MatchCountdownDisplay = () => {
+  const { match } = useMatch();
+  const [remaining, setRemaining] = useState("");
+
+  useEffect(() => {
+    if (!match.matchStartTime) {
+      setRemaining("");
+      return;
+    }
+
+    const update = () => {
+      const now = moment();
+      const target = moment(match.matchStartTime, "HH:mm");
+      if (!target.isValid()) {
+        setRemaining("");
+        return;
+      }
+      if (target <= now) {
+        target.add(1, "days");
+      }
+      const diff = target.diff(now);
+      if (diff <= 0) {
+        setRemaining("00:00");
+        return;
+      }
+      const minutes = Math.floor(diff / 60000);
+      const seconds = Math.floor((diff % 60000) / 1000);
+      setRemaining(
+        `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`,
+      );
+    };
+
+    update();
+    const interval = setInterval(update, 1000);
+    return () => clearInterval(interval);
+  }, [match.matchStartTime]);
+
+  if (!match.matchStartTime || !remaining) {
+    return null;
+  }
+
+  return (
+    <div className="match-countdown-display">
+      <span className="match-countdown-label">Niðurtalning:</span>
+      <span className="match-countdown-time">{remaining}</span>
+    </div>
+  );
+};
+
+export default MatchCountdownDisplay;

--- a/clock/src/controller/MatchCountdownDisplay.tsx
+++ b/clock/src/controller/MatchCountdownDisplay.tsx
@@ -2,40 +2,31 @@ import { useState, useEffect } from "react";
 import moment from "moment";
 import { useMatch } from "../contexts/FirebaseStateContext";
 
+const computeRemaining = (matchStartTime: string): string => {
+  const now = moment();
+  const target = moment(matchStartTime, "HH:mm");
+  if (!target.isValid()) return "";
+  if (target <= now) target.add(1, "days");
+  const diff = target.diff(now);
+  if (diff <= 0) return "00:00";
+  const minutes = Math.floor(diff / 60000);
+  const seconds = Math.floor((diff % 60000) / 1000);
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+};
+
 const MatchCountdownDisplay = () => {
   const { match } = useMatch();
-  const [remaining, setRemaining] = useState("");
+  const [remaining, setRemaining] = useState(() =>
+    match.matchStartTime ? computeRemaining(match.matchStartTime) : "",
+  );
 
   useEffect(() => {
-    if (!match.matchStartTime) {
-      setRemaining("");
-      return;
-    }
+    if (!match.matchStartTime) return;
 
-    const update = () => {
-      const now = moment();
-      const target = moment(match.matchStartTime, "HH:mm");
-      if (!target.isValid()) {
-        setRemaining("");
-        return;
-      }
-      if (target <= now) {
-        target.add(1, "days");
-      }
-      const diff = target.diff(now);
-      if (diff <= 0) {
-        setRemaining("00:00");
-        return;
-      }
-      const minutes = Math.floor(diff / 60000);
-      const seconds = Math.floor((diff % 60000) / 1000);
-      setRemaining(
-        `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`,
-      );
-    };
+    const interval = setInterval(() => {
+      setRemaining(computeRemaining(match.matchStartTime ?? ""));
+    }, 1000);
 
-    update();
-    const interval = setInterval(update, 1000);
     return () => clearInterval(interval);
   }, [match.matchStartTime]);
 

--- a/clock/src/controller/asset/team/TodaysMatches.tsx
+++ b/clock/src/controller/asset/team/TodaysMatches.tsx
@@ -16,6 +16,7 @@ import {
   type Team,
 } from "../../../api/client";
 import { transformLineups, getTeamId } from "../../../lib/matchUtils";
+import { normalizeTimeTo24h } from "../../../utils/matchUtils";
 
 const getClubName = (team: Team): string => team.parent?.name ?? team.name;
 
@@ -70,12 +71,11 @@ const TodaysMatches = (): React.JSX.Element => {
       updateMatch({
         homeTeam: getClubName(match.homeTeam),
         awayTeam: getClubName(match.awayTeam),
-        matchStartTime: new Date(match.dateTimeUTC).toLocaleTimeString(
-          "is-IS",
-          {
+        matchStartTime: normalizeTimeTo24h(
+          new Date(match.dateTimeUTC).toLocaleTimeString("is-IS", {
             hour: "2-digit",
             minute: "2-digit",
-          },
+          }),
         ),
         ksiMatchId: match.id,
       });
@@ -104,10 +104,12 @@ const TodaysMatches = (): React.JSX.Element => {
     updateMatch({
       homeTeam: getClubName(match.homeTeam),
       awayTeam: getClubName(match.awayTeam),
-      matchStartTime: new Date(match.dateTimeUTC).toLocaleTimeString("is-IS", {
-        hour: "2-digit",
-        minute: "2-digit",
-      }),
+      matchStartTime: normalizeTimeTo24h(
+        new Date(match.dateTimeUTC).toLocaleTimeString("is-IS", {
+          hour: "2-digit",
+          minute: "2-digit",
+        }),
+      ),
       ksiMatchId: match.id,
     });
 

--- a/clock/src/utils/matchUtils.ts
+++ b/clock/src/utils/matchUtils.ts
@@ -59,3 +59,38 @@ export function translateTeam(team: "home" | "away"): string {
   };
   return translations[team] || team;
 }
+
+/**
+ * Normalizes a time string to 24h HH:mm format.
+ * Handles AM/PM formats (e.g. "7:15 PM" → "19:15") and
+ * already-valid 24h formats (e.g. "19:15" → "19:15").
+ */
+export function normalizeTimeTo24h(time: string): string {
+  const trimmed = time.trim();
+
+  // Already in HH:mm 24h format
+  if (/^\d{1,2}:\d{2}$/.test(trimmed)) {
+    return trimmed;
+  }
+
+  // Match AM/PM patterns like "7:15 PM", "12:00 AM", "11:30 am"
+  const amPmMatch = trimmed.match(
+    /^(\d{1,2}):(\d{2})\s*(AM|PM|am|pm|a\.m\.|p\.m\.)$/i,
+  );
+  if (amPmMatch) {
+    const [, hoursStr, minutes, periodRaw] = amPmMatch;
+    let hours = parseInt(hoursStr!, 10);
+    const period = periodRaw!.toUpperCase().replace(/\./g, "");
+
+    if (period === "PM" && hours !== 12) {
+      hours += 12;
+    } else if (period === "AM" && hours === 12) {
+      hours = 0;
+    }
+
+    return `${String(hours).padStart(2, "0")}:${minutes!}`;
+  }
+
+  // Couldn't parse — return as-is
+  return trimmed;
+}

--- a/clock/src/utils/timeUtils.ts
+++ b/clock/src/utils/timeUtils.ts
@@ -1,5 +1,15 @@
+import moment from "moment";
+
 const pad = (x: number | string): string =>
   `${x}`.length < 2 ? pad(`0${x}`) : `${x}`;
+
+export const msUntilMatchStart = (matchStartTime: string): number | null => {
+  const now = moment();
+  const target = moment(matchStartTime, "HH:mm", true);
+  if (!target.isValid()) return null;
+  if (target <= now) target.add(1, "days");
+  return target.valueOf() - now.valueOf();
+};
 
 export const formatTime = (mins: number, secs: number): string =>
   `${pad(mins)}:${pad(secs)}`;


### PR DESCRIPTION
## Summary

- **Countdown display**: Adds a live countdown timer (minutes:seconds) below the match control buttons that is ALWAYS visible when `matchStartTime` is set. This lets the controller see time remaining to kickoff even while showing ads/videos.
- **AM/PM normalization**: Adds `normalizeTimeTo24h()` utility that converts 12-hour time formats (e.g. "7:15 PM" → "19:15") to 24-hour HH:mm format. Applied automatically when fetching matches from the KSI API and on blur of the manual time input field.

## Changes

- `clock/src/controller/MatchCountdownDisplay.tsx` — New component with live countdown
- `clock/src/utils/matchUtils.ts` — `normalizeTimeTo24h()` utility
- `clock/src/controller/asset/team/TodaysMatches.tsx` — Apply normalization on API fetch
- `clock/src/controller/MatchActionSettings.tsx` — Apply normalization on input blur
- `clock/src/App.tsx` — Render countdown display below MatchActions
- `clock/src/controller/Controller.css` — Countdown styling