### PR TITLE
Live viewport updates from Firebase + admin screen editor

### DIFF
--- a/clock/src/App.spec.tsx
+++ b/clock/src/App.spec.tsx
@@ -82,8 +82,8 @@ function setupState1() {
     auth: { isLoaded: true, isEmpty: true },
     listenPrefix: "",
     setListenPrefix: vi.fn(),
-    screenViewport: null,
-    setScreenViewport: vi.fn(),
+    screenKey: null,
+    setScreenKey: vi.fn(),
     available: [],
     email: "",
     setEmail: vi.fn(),
@@ -102,19 +102,19 @@ function setupState2(
   view: string = VIEWS.idle,
   overrides?: {
     setListenPrefix?: (prefix: string) => void;
-    setScreenViewport?: (vp: unknown) => void;
+    setScreenKey?: (vp: unknown) => void;
   },
 ) {
   const setListenPrefix =
     overrides?.setListenPrefix ?? vi.fn<(prefix: string) => void>();
-  const setScreenViewport =
-    overrides?.setScreenViewport ?? vi.fn<(vp: unknown) => void>();
+  const setScreenKey =
+    overrides?.setScreenKey ?? vi.fn<(vp: unknown) => void>();
   mockedUseLocalState.mockReturnValue({
     auth: { isLoaded: true, isEmpty: true },
     listenPrefix: "vikinni",
     setListenPrefix,
-    screenViewport: null,
-    setScreenViewport,
+    screenKey: null,
+    setScreenKey,
     available: [],
     email: "",
     setEmail: vi.fn(),
@@ -127,26 +127,26 @@ function setupState2(
     view: { vp: defaultViewport, background: "Default" },
     ready: true,
   } as unknown as ReturnType<typeof useFirebaseState>);
-  return { setListenPrefix, setScreenViewport };
+  return { setListenPrefix, setScreenKey };
 }
 
 function setupState3(
   view: string = VIEWS.idle,
   overrides?: {
     setListenPrefix?: (prefix: string) => void;
-    setScreenViewport?: (vp: unknown) => void;
+    setScreenKey?: (vp: unknown) => void;
   },
 ) {
   const setListenPrefix =
     overrides?.setListenPrefix ?? vi.fn<(prefix: string) => void>();
-  const setScreenViewport =
-    overrides?.setScreenViewport ?? vi.fn<(vp: unknown) => void>();
+  const setScreenKey =
+    overrides?.setScreenKey ?? vi.fn<(vp: unknown) => void>();
   mockedUseLocalState.mockReturnValue({
     auth: { isLoaded: true, isEmpty: false, email: "test@test.com" },
     listenPrefix: "vikinni",
     setListenPrefix,
-    screenViewport: null,
-    setScreenViewport,
+    screenKey: null,
+    setScreenKey,
     available: ["vikinni"],
     email: "test@test.com",
     setEmail: vi.fn(),
@@ -172,7 +172,7 @@ function setupState3(
   mockedUseRemoteSettings.mockReturnValue({
     listenPrefix: "vikinni",
   } as unknown as ReturnType<typeof useRemoteSettings>);
-  return { setListenPrefix, setScreenViewport };
+  return { setListenPrefix, setScreenKey };
 }
 
 describe("App", () => {
@@ -295,7 +295,7 @@ describe("App", () => {
       const mockSetScreenViewport = vi.fn();
       setupState3(VIEWS.idle, {
         setListenPrefix: mockSetListenPrefix,
-        setScreenViewport: mockSetScreenViewport,
+        setScreenKey: mockSetScreenViewport,
       });
       render(<App />);
 
@@ -311,7 +311,7 @@ describe("App", () => {
       const mockSetScreenViewport = vi.fn();
       setupState3(VIEWS.idle, {
         setListenPrefix: mockSetListenPrefix,
-        setScreenViewport: mockSetScreenViewport,
+        setScreenKey: mockSetScreenViewport,
       });
       render(<App />);
 
@@ -377,8 +377,8 @@ describe("App", () => {
         auth: { isLoaded: true, isEmpty: true },
         listenPrefix: "vikinni",
         setListenPrefix: vi.fn(),
-        screenViewport: null,
-        setScreenViewport: vi.fn(),
+        screenKey: null,
+        setScreenKey: vi.fn(),
         available: [],
         email: "",
         setEmail: vi.fn(),
@@ -412,8 +412,8 @@ describe("App", () => {
         auth: { isLoaded: true, isEmpty: true },
         listenPrefix: "vikinni",
         setListenPrefix: vi.fn(),
-        screenViewport: null,
-        setScreenViewport: vi.fn(),
+        screenKey: null,
+        setScreenKey: vi.fn(),
         available: [],
         email: "",
         setEmail: vi.fn(),
@@ -444,8 +444,8 @@ describe("App", () => {
         auth: { isLoaded: true, isEmpty: true },
         listenPrefix: "vikinni",
         setListenPrefix: vi.fn(),
-        screenViewport: null,
-        setScreenViewport: vi.fn(),
+        screenKey: null,
+        setScreenKey: vi.fn(),
         available: [],
         email: "",
         setEmail: vi.fn(),
@@ -470,8 +470,8 @@ describe("App", () => {
         auth: { isLoaded: false, isEmpty: true },
         listenPrefix: "vikinni",
         setListenPrefix: vi.fn(),
-        screenViewport: null,
-        setScreenViewport: vi.fn(),
+        screenKey: null,
+        setScreenKey: vi.fn(),
         available: [],
         email: "",
         setEmail: vi.fn(),

--- a/clock/src/App.tsx
+++ b/clock/src/App.tsx
@@ -151,8 +151,7 @@ const ClearOverlayButton = () => {
 function App() {
   useGlobalShortcuts();
   const { controller, view: viewState, ready } = useFirebaseState();
-  const { auth, listenPrefix, setListenPrefix, setScreenViewport } =
-    useLocalState();
+  const { auth, listenPrefix, setListenPrefix, setScreenKey } = useLocalState();
 
   const { view } = controller;
   const {
@@ -260,7 +259,7 @@ function App() {
           appearance="primary"
           size="lg"
           onClick={() => {
-            setScreenViewport(null);
+            setScreenKey(null);
             setListenPrefix("");
           }}
           style={{ position: "fixed", bottom: 16, right: 16, zIndex: 9999 }}
@@ -278,12 +277,12 @@ function App() {
 
   // State 4: authenticated + listenPrefix set — full UI with disconnect/logout buttons
   const disconnectScreen = () => {
-    setScreenViewport(null);
+    setScreenKey(null);
     setListenPrefix("");
   };
 
   const logout = () => {
-    setScreenViewport(null);
+    setScreenKey(null);
     setListenPrefix("");
     firebaseAuth.logout().catch(console.error);
   };

--- a/clock/src/admin/AdminPortal.tsx
+++ b/clock/src/admin/AdminPortal.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "../contexts/LocalStateContext";
 import { useAdminData } from "./useAdminData";
 import { ManageUsers } from "./ManageUsers";
 import { InvitationTable } from "./InvitationTable";
+import { LocationsManager } from "./LocationsManager";
 import "rsuite/dist/rsuite.min.css";
 import "./AdminPortal.css";
 
@@ -90,6 +91,12 @@ export function AdminPortal() {
                 invitations={invitations}
                 locations={locations}
               />
+            </Panel>
+          </section>
+
+          <section className="admin-section">
+            <Panel header="Staðsetningar og skjáir" bordered>
+              <LocationsManager />
             </Panel>
           </section>
         </>

--- a/clock/src/admin/LocationsManager.css
+++ b/clock/src/admin/LocationsManager.css
@@ -1,0 +1,67 @@
+.loc-manager {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.loc-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 0.5rem;
+}
+
+.loc-panel {
+  margin-bottom: 0.5rem;
+}
+
+.loc-key-badge {
+  display: inline-block;
+  padding: 0.1rem 0.5rem;
+  background: #f0f0f5;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  color: #666;
+  font-family: monospace;
+}
+
+.loc-fields {
+  padding: 0.25rem 0;
+}
+
+.loc-label {
+  display: block;
+  font-size: 0.75rem;
+  color: #666;
+  margin-bottom: 2px;
+}
+
+.loc-screens-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 1rem;
+  margin-bottom: 0.5rem;
+  padding-bottom: 0.25rem;
+  border-bottom: 1px solid #eee;
+}
+
+.loc-screens-labels {
+  margin-bottom: 0.25rem;
+  color: #888;
+}
+
+.loc-screen-row {
+  margin-bottom: 0.4rem;
+}
+
+.loc-modal-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.loc-modal-fields hr {
+  border: none;
+  border-top: 1px solid #eee;
+  margin: 0.5rem 0;
+}

--- a/clock/src/admin/LocationsManager.tsx
+++ b/clock/src/admin/LocationsManager.tsx
@@ -1,0 +1,558 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  Panel,
+  Button,
+  Input,
+  InputNumber,
+  Modal,
+  IconButton,
+  FlexboxGrid,
+} from "rsuite";
+import PlusIcon from "@rsuite/icons/Plus";
+import { ref, onValue, set } from "firebase/database";
+import { database } from "../firebase";
+import "./LocationsManager.css";
+
+interface ScreenDef {
+  key: string;
+  name: string;
+  fontSize: string;
+  style: { width: number; height: number };
+}
+
+interface LocationConfig {
+  homeTeam?: number;
+  goalScorerBackground?: string;
+}
+
+interface LocationData {
+  label: string;
+  pitchIds: number[];
+  config?: LocationConfig;
+  screens: ScreenDef[];
+}
+
+type LocationsMap = Record<string, LocationData>;
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "")
+    .replace(/^-+|-+$/g, "");
+}
+
+function useLocationsData(): {
+  locations: LocationsMap;
+  loading: boolean;
+  error: string | null;
+} {
+  const [locations, setLocations] = useState<LocationsMap>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const locRef = ref(database, "locations");
+    const unsubscribe = onValue(
+      locRef,
+      (snapshot) => {
+        const data = snapshot.val() as Record<string, unknown> | null;
+        if (data && typeof data === "object") {
+          const parsed: LocationsMap = {};
+          for (const [key, raw] of Object.entries(data)) {
+            if (raw && typeof raw === "object") {
+              const r = raw as Record<string, unknown>;
+              const screens: ScreenDef[] = [];
+              if (Array.isArray(r.screens)) {
+                for (const s of r.screens) {
+                  if (s && typeof s === "object") {
+                    const sc = s as Record<string, unknown>;
+                    const style =
+                      sc.style && typeof sc.style === "object"
+                        ? (sc.style as Record<string, unknown>)
+                        : {};
+                    screens.push({
+                      key: typeof sc.key === "string" ? sc.key : "",
+                      name: typeof sc.name === "string" ? sc.name : "",
+                      fontSize:
+                        typeof sc.fontSize === "string" ? sc.fontSize : "100%",
+                      style: {
+                        width: Number(style.width ?? 512),
+                        height: Number(style.height ?? 400),
+                      },
+                    });
+                  }
+                }
+              }
+              const pitchIds: number[] = Array.isArray(r.pitchIds)
+                ? (r.pitchIds as unknown[]).map(Number).filter((n) => !isNaN(n))
+                : [];
+              const config: LocationConfig | undefined =
+                r.config && typeof r.config === "object"
+                  ? (() => {
+                      const c = r.config as Record<string, unknown>;
+                      const cfg: LocationConfig = {};
+                      if (typeof c.homeTeam === "number")
+                        cfg.homeTeam = c.homeTeam;
+                      if (typeof c.goalScorerBackground === "string")
+                        cfg.goalScorerBackground = c.goalScorerBackground;
+                      return Object.keys(cfg).length > 0 ? cfg : undefined;
+                    })()
+                  : undefined;
+              parsed[key] = {
+                label:
+                  typeof r.label === "string"
+                    ? r.label
+                    : typeof r.name === "string"
+                      ? r.name
+                      : key,
+                pitchIds,
+                config,
+                screens,
+              };
+            }
+          }
+          setLocations(parsed);
+        } else {
+          setLocations({});
+        }
+        setLoading(false);
+      },
+      (err) => {
+        setError(err.message);
+        setLoading(false);
+      },
+    );
+    return () => unsubscribe();
+  }, []);
+
+  return { locations, loading, error };
+}
+
+function ScreenEditor({
+  screen,
+  onChange,
+}: {
+  screen: ScreenDef;
+  onChange: (updated: ScreenDef) => void;
+}) {
+  return (
+    <div className="loc-screen-row">
+      <FlexboxGrid align="middle" style={{ gap: "0.5rem" }}>
+        <FlexboxGrid.Item colspan={5}>
+          <Input
+            size="sm"
+            placeholder="Nafn"
+            value={screen.name}
+            onChange={(val) => onChange({ ...screen, name: val })}
+          />
+        </FlexboxGrid.Item>
+        <FlexboxGrid.Item colspan={4}>
+          <Input
+            size="sm"
+            placeholder="Lykill"
+            value={screen.key}
+            onChange={(val) => onChange({ ...screen, key: val })}
+          />
+        </FlexboxGrid.Item>
+        <FlexboxGrid.Item colspan={4}>
+          <Input
+            size="sm"
+            placeholder="Leturstærð"
+            value={screen.fontSize}
+            onChange={(val) => onChange({ ...screen, fontSize: val })}
+          />
+        </FlexboxGrid.Item>
+        <FlexboxGrid.Item colspan={4}>
+          <InputNumber
+            size="sm"
+            prefix="W"
+            value={screen.style.width}
+            onChange={(val) =>
+              onChange({
+                ...screen,
+                style: { ...screen.style, width: Number(val) || 0 },
+              })
+            }
+          />
+        </FlexboxGrid.Item>
+        <FlexboxGrid.Item colspan={4}>
+          <InputNumber
+            size="sm"
+            prefix="H"
+            value={screen.style.height}
+            onChange={(val) =>
+              onChange({
+                ...screen,
+                style: { ...screen.style, height: Number(val) || 0 },
+              })
+            }
+          />
+        </FlexboxGrid.Item>
+      </FlexboxGrid>
+    </div>
+  );
+}
+
+function LocationEditor({
+  venueKey,
+  location,
+}: {
+  venueKey: string;
+  location: LocationData;
+}) {
+  const [label, setLabel] = useState(location.label);
+  const [pitchIdsStr, setPitchIdsStr] = useState(location.pitchIds.join(", "));
+  const [homeTeam, setHomeTeam] = useState<number | null>(
+    location.config?.homeTeam ?? null,
+  );
+  const [goalScorerBg, setGoalScorerBg] = useState(
+    location.config?.goalScorerBackground ?? "",
+  );
+  const [screens, setScreens] = useState<ScreenDef[]>(location.screens);
+  const [dirty, setDirty] = useState(false);
+
+  const markDirty = useCallback(() => setDirty(true), []);
+
+  const save = useCallback(() => {
+    const pitchIds = pitchIdsStr
+      .split(",")
+      .map((s) => Number(s.trim()))
+      .filter((n) => !isNaN(n) && n > 0);
+
+    const config: LocationConfig = {};
+    if (homeTeam !== null && homeTeam > 0) config.homeTeam = homeTeam;
+    if (goalScorerBg.trim()) config.goalScorerBackground = goalScorerBg.trim();
+
+    const data: Record<string, unknown> = {
+      label,
+      pitchIds,
+      screens,
+    };
+    if (Object.keys(config).length > 0) {
+      data.config = config;
+    }
+
+    const locRef = ref(database, `locations/${venueKey}`);
+    void set(locRef, data);
+    setDirty(false);
+  }, [venueKey, label, pitchIdsStr, homeTeam, goalScorerBg, screens]);
+
+  const addScreen = () => {
+    const newScreen: ScreenDef = {
+      key: "",
+      name: "",
+      fontSize: "100%",
+      style: { width: 512, height: 400 },
+    };
+    setScreens([...screens, newScreen]);
+    markDirty();
+  };
+
+  const updateScreen = (index: number, updated: ScreenDef) => {
+    const next = [...screens];
+    next[index] = updated;
+    setScreens(next);
+    markDirty();
+  };
+
+  return (
+    <Panel
+      header={
+        <span>
+          <strong>{location.label}</strong>{" "}
+          <span className="loc-key-badge">{venueKey}</span>
+        </span>
+      }
+      bordered
+      collapsible
+      className="loc-panel"
+    >
+      <div className="loc-fields">
+        <FlexboxGrid
+          align="middle"
+          style={{ gap: "0.5rem", marginBottom: "0.5rem" }}
+        >
+          <FlexboxGrid.Item colspan={6}>
+            <label className="loc-label">Heiti</label>
+            <Input
+              size="sm"
+              value={label}
+              onChange={(val) => {
+                setLabel(val);
+                markDirty();
+              }}
+            />
+          </FlexboxGrid.Item>
+          <FlexboxGrid.Item colspan={6}>
+            <label className="loc-label">Völlur (pitchIds)</label>
+            <Input
+              size="sm"
+              placeholder="102, 103"
+              value={pitchIdsStr}
+              onChange={(val) => {
+                setPitchIdsStr(val);
+                markDirty();
+              }}
+            />
+          </FlexboxGrid.Item>
+          <FlexboxGrid.Item colspan={4}>
+            <label className="loc-label">Heimalið (ID)</label>
+            <InputNumber
+              size="sm"
+              value={homeTeam ?? undefined}
+              onChange={(val) => {
+                setHomeTeam(val ? Number(val) : null);
+                markDirty();
+              }}
+            />
+          </FlexboxGrid.Item>
+          <FlexboxGrid.Item colspan={6}>
+            <label className="loc-label">Markaskorari bakgr.</label>
+            <Input
+              size="sm"
+              placeholder="config/baddi.gif"
+              value={goalScorerBg}
+              onChange={(val) => {
+                setGoalScorerBg(val);
+                markDirty();
+              }}
+            />
+          </FlexboxGrid.Item>
+        </FlexboxGrid>
+
+        <div className="loc-screens-header">
+          <strong>Skjáir</strong>
+          <IconButton
+            icon={<PlusIcon />}
+            size="xs"
+            appearance="ghost"
+            onClick={addScreen}
+          >
+            Nýr skjár
+          </IconButton>
+        </div>
+
+        <div className="loc-screens-labels">
+          <FlexboxGrid style={{ gap: "0.5rem" }}>
+            <FlexboxGrid.Item colspan={5}>
+              <small>Nafn</small>
+            </FlexboxGrid.Item>
+            <FlexboxGrid.Item colspan={4}>
+              <small>Lykill</small>
+            </FlexboxGrid.Item>
+            <FlexboxGrid.Item colspan={4}>
+              <small>Leturstærð</small>
+            </FlexboxGrid.Item>
+            <FlexboxGrid.Item colspan={4}>
+              <small>Breidd</small>
+            </FlexboxGrid.Item>
+            <FlexboxGrid.Item colspan={4}>
+              <small>Hæð</small>
+            </FlexboxGrid.Item>
+          </FlexboxGrid>
+        </div>
+
+        {screens.map((screen, i) => (
+          <ScreenEditor
+            key={i}
+            screen={screen}
+            onChange={(updated) => updateScreen(i, updated)}
+          />
+        ))}
+
+        {dirty && (
+          <Button
+            appearance="primary"
+            size="sm"
+            onClick={save}
+            style={{ marginTop: "0.75rem" }}
+          >
+            Vista breytingar
+          </Button>
+        )}
+      </div>
+    </Panel>
+  );
+}
+
+function NewLocationModal({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
+  const [label, setLabel] = useState("");
+  const [venueKey, setVenueKey] = useState("");
+  const [autoKey, setAutoKey] = useState(true);
+  const [screenName, setScreenName] = useState("");
+  const [screenKey, setScreenKey] = useState("");
+  const [fontSize, setFontSize] = useState("100%");
+  const [width, setWidth] = useState(512);
+  const [height, setHeight] = useState(400);
+
+  const effectiveKey = autoKey ? slugify(label) : venueKey;
+
+  const canSave =
+    effectiveKey.length > 0 &&
+    label.trim().length > 0 &&
+    screenKey.trim().length > 0;
+
+  const handleSave = () => {
+    const data: LocationData = {
+      label: label.trim(),
+      pitchIds: [],
+      screens: [
+        {
+          key: screenKey.trim(),
+          name: screenName.trim() || "Skjár",
+          fontSize,
+          style: { width, height },
+        },
+      ],
+    };
+    const locRef = ref(database, `locations/${effectiveKey}`);
+    void set(locRef, data);
+    onClose();
+    setLabel("");
+    setVenueKey("");
+    setScreenName("");
+    setScreenKey("");
+    setFontSize("100%");
+    setWidth(512);
+    setHeight(400);
+    setAutoKey(true);
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} size="sm">
+      <Modal.Header>
+        <Modal.Title>Ný staðsetning</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <div className="loc-modal-fields">
+          <label className="loc-label">Heiti</label>
+          <Input
+            value={label}
+            onChange={(val) => {
+              setLabel(val);
+              if (autoKey) setVenueKey(slugify(val));
+            }}
+            placeholder="t.d. Víkin úti"
+          />
+
+          <label className="loc-label">Lykill (slug)</label>
+          <Input
+            value={autoKey ? slugify(label) : venueKey}
+            onChange={(val) => {
+              setAutoKey(false);
+              setVenueKey(val);
+            }}
+            placeholder="vikuti"
+          />
+
+          <hr />
+          <strong>Fyrsti skjár</strong>
+
+          <label className="loc-label">Nafn skjás</label>
+          <Input
+            value={screenName}
+            onChange={setScreenName}
+            placeholder="Skjár"
+          />
+
+          <label className="loc-label">Lykill skjás</label>
+          <Input
+            value={screenKey}
+            onChange={setScreenKey}
+            placeholder="outside"
+          />
+
+          <FlexboxGrid style={{ gap: "0.5rem", marginTop: "0.5rem" }}>
+            <FlexboxGrid.Item colspan={8}>
+              <label className="loc-label">Leturstærð</label>
+              <Input value={fontSize} onChange={setFontSize} size="sm" />
+            </FlexboxGrid.Item>
+            <FlexboxGrid.Item colspan={8}>
+              <label className="loc-label">Breidd</label>
+              <InputNumber
+                value={width}
+                onChange={(val) => setWidth(Number(val) || 512)}
+                size="sm"
+              />
+            </FlexboxGrid.Item>
+            <FlexboxGrid.Item colspan={8}>
+              <label className="loc-label">Hæð</label>
+              <InputNumber
+                value={height}
+                onChange={(val) => setHeight(Number(val) || 400)}
+                size="sm"
+              />
+            </FlexboxGrid.Item>
+          </FlexboxGrid>
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button appearance="primary" onClick={handleSave} disabled={!canSave}>
+          Búa til
+        </Button>
+        <Button appearance="subtle" onClick={onClose}>
+          Hætta við
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}
+
+export function LocationsManager() {
+  const { locations, loading, error } = useLocationsData();
+  const [showNewModal, setShowNewModal] = useState(false);
+
+  if (loading) {
+    return (
+      <p style={{ padding: "1rem", color: "#999" }}>Hleð staðsetningum...</p>
+    );
+  }
+
+  if (error) {
+    return <p style={{ padding: "1rem", color: "red" }}>{error}</p>;
+  }
+
+  const entries = Object.entries(locations).sort((a, b) =>
+    a[1].label.localeCompare(b[1].label, "is"),
+  );
+
+  return (
+    <div className="loc-manager">
+      <div className="loc-toolbar">
+        <Button
+          appearance="primary"
+          size="sm"
+          startIcon={<PlusIcon />}
+          onClick={() => setShowNewModal(true)}
+        >
+          Ný staðsetning
+        </Button>
+      </div>
+
+      {entries.length === 0 ? (
+        <p className="admin-table-empty">Engar staðsetningar skráðar</p>
+      ) : (
+        entries.map(([key, loc]) => (
+          <LocationEditor
+            key={`${key}-${JSON.stringify(loc)}`}
+            venueKey={key}
+            location={loc}
+          />
+        ))
+      )}
+
+      <NewLocationModal
+        open={showNewModal}
+        onClose={() => setShowNewModal(false)}
+      />
+    </div>
+  );
+}

--- a/clock/src/contexts/FirebaseStateContext.spec.tsx
+++ b/clock/src/contexts/FirebaseStateContext.spec.tsx
@@ -84,7 +84,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix=""
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -111,7 +111,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix=""
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestControllerConsumer
             onMount={(api) => {
@@ -140,7 +140,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -170,7 +170,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -217,7 +217,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestControllerConsumer
             onMount={(api) => {
@@ -247,7 +247,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test"
           isAuthenticated={false}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -271,7 +271,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -298,7 +298,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -319,7 +319,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -344,7 +344,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -369,7 +369,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -394,7 +394,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -415,7 +415,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -440,7 +440,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -468,7 +468,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -489,7 +489,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -514,7 +514,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -543,7 +543,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -576,7 +576,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestControllerConsumer
             onMount={(api) => {
@@ -601,7 +601,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestControllerConsumer
             onMount={(api) => {
@@ -626,7 +626,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestControllerConsumer
             onMount={(api) => {
@@ -656,7 +656,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestControllerConsumer
             onMount={(api) => {
@@ -677,7 +677,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestControllerConsumer
             onMount={(api) => {
@@ -702,7 +702,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestControllerConsumer
             onMount={(api) => {
@@ -729,7 +729,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestControllerConsumer
             onMount={(api) => {
@@ -756,7 +756,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -781,7 +781,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -806,7 +806,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -831,7 +831,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -856,7 +856,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -881,7 +881,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -906,7 +906,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -933,7 +933,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -961,7 +961,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -993,7 +993,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1018,7 +1018,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1043,7 +1043,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1068,7 +1068,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1090,7 +1090,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1115,7 +1115,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1140,7 +1140,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1162,7 +1162,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1184,7 +1184,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1211,7 +1211,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1244,7 +1244,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1277,7 +1277,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1298,7 +1298,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1323,7 +1323,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1357,7 +1357,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestControllerConsumer
             onMount={(api) => {
@@ -1386,7 +1386,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestControllerConsumer
             onMount={(api) => {
@@ -1417,7 +1417,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestControllerConsumer
             onMount={(api) => {
@@ -1457,7 +1457,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestControllerConsumer
             onMount={(api) => {
@@ -1527,7 +1527,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestViewConsumer
             onMount={(api) => {
@@ -1557,7 +1557,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestViewConsumer
             onMount={(api) => {
@@ -1582,7 +1582,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestViewConsumer
             onMount={(api) => {
@@ -1609,7 +1609,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestViewConsumer
             onMount={(api) => {
@@ -1636,7 +1636,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1669,7 +1669,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1694,7 +1694,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1715,7 +1715,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1740,7 +1740,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1761,7 +1761,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1800,7 +1800,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestControllerConsumer
             onMount={(api) => {
@@ -1833,7 +1833,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1853,7 +1853,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1874,7 +1874,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1894,7 +1894,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {
@@ -1919,7 +1919,7 @@ describe("FirebaseStateContext", () => {
         <FirebaseStateProvider
           listenPrefix="test-location"
           isAuthenticated={true}
-          screenViewport={null}
+          screenKey={null}
         >
           <TestMatchConsumer
             onMount={(api) => {

--- a/clock/src/contexts/FirebaseStateContext.tsx
+++ b/clock/src/contexts/FirebaseStateContext.tsx
@@ -324,14 +324,14 @@ interface FirebaseStateProviderProps {
   children: ReactNode;
   listenPrefix: string;
   isAuthenticated: boolean;
-  screenViewport: ViewPort | null;
+  screenKey: string | null;
 }
 
 export const FirebaseStateProvider: React.FC<FirebaseStateProviderProps> = ({
   children,
   listenPrefix,
   isAuthenticated,
-  screenViewport,
+  screenKey,
 }) => {
   const [match, setMatch] = useState<Match>(defaultMatch);
   const [controller, setController] =
@@ -1342,13 +1342,14 @@ export const FirebaseStateProvider: React.FC<FirebaseStateProviderProps> = ({
     [listenPrefix, isAuthenticated],
   );
 
-  // Apply screen viewport override from "Birta skjá" selection.
-  // The screenViewport from locations.X.screens[Y] takes precedence over
-  // the Firebase view.vp, which may not match the physical screen config.
+  // Resolve viewport from live Firebase locations data by screenKey.
+  // When admin changes screen dimensions, listeners updates and this recomputes.
   const effectiveView = useMemo<ViewState>(() => {
-    if (!screenViewport) return view;
-    return { ...view, vp: screenViewport };
-  }, [view, screenViewport]);
+    if (!screenKey) return view;
+    const found = listeners.screens.find((s) => s.screen.key === screenKey);
+    if (!found) return view;
+    return { ...view, vp: found.screen };
+  }, [view, screenKey, listeners.screens]);
 
   const value = useMemo(
     () => ({

--- a/clock/src/contexts/FirebaseStateContext.tsx
+++ b/clock/src/contexts/FirebaseStateContext.tsx
@@ -1344,12 +1344,16 @@ export const FirebaseStateProvider: React.FC<FirebaseStateProviderProps> = ({
 
   // Resolve viewport from live Firebase locations data by screenKey.
   // When admin changes screen dimensions, listeners updates and this recomputes.
+  // Filter by listenPrefix (location key) since multiple locations can have
+  // screens with the same key (e.g. "outside" at different venues).
   const effectiveView = useMemo<ViewState>(() => {
     if (!screenKey) return view;
-    const found = listeners.screens.find((s) => s.screen.key === screenKey);
+    const found = listeners.screens.find(
+      (s) => s.screen.key === screenKey && s.key === listenPrefix,
+    );
     if (!found) return view;
     return { ...view, vp: found.screen };
-  }, [view, screenKey, listeners.screens]);
+  }, [view, screenKey, listeners.screens, listenPrefix]);
 
   const value = useMemo(
     () => ({

--- a/clock/src/contexts/LocalStateContext.tsx
+++ b/clock/src/contexts/LocalStateContext.tsx
@@ -64,7 +64,24 @@ export function LocalStateProvider({ children }: { children: ReactNode }) {
 
   // Screen key (set when selecting a screen via "Birta skjá")
   const [screenKey, setScreenKeyState] = useState<string | null>(() => {
-    return localStorage.getItem(SCREEN_KEY_KEY) || null;
+    const stored = localStorage.getItem(SCREEN_KEY_KEY);
+    if (stored) return stored;
+
+    // Migration: extract key from old screenViewport localStorage format
+    const oldViewport = localStorage.getItem("clock_screenViewport");
+    if (oldViewport) {
+      try {
+        const parsed = JSON.parse(oldViewport) as { key?: string };
+        if (parsed.key) {
+          localStorage.setItem(SCREEN_KEY_KEY, parsed.key);
+          localStorage.removeItem("clock_screenViewport");
+          return parsed.key;
+        }
+      } catch {
+        // ignore parse errors
+      }
+    }
+    return null;
   });
 
   // Login Form State

--- a/clock/src/contexts/LocalStateContext.tsx
+++ b/clock/src/contexts/LocalStateContext.tsx
@@ -9,7 +9,6 @@ import { User } from "firebase/auth";
 import { ref, onValue } from "firebase/database";
 import { firebaseAuth } from "../firebaseAuth";
 import { database } from "../firebase";
-import type { ViewPort } from "../types";
 
 export interface FirebaseAuthState {
   isLoaded: boolean;
@@ -28,9 +27,9 @@ interface LocalStateContextType {
   setListenPrefix: (prefix: string) => void;
   available: string[] | null;
 
-  // Screen viewport override (from "Birta skjá" selection)
-  screenViewport: ViewPort | null;
-  setScreenViewport: (vp: ViewPort | null) => void;
+  // Screen key (from "Birta skjá" selection) — used to resolve viewport from live Firebase locations
+  screenKey: string | null;
+  setScreenKey: (key: string | null) => void;
 
   // Login form state
   email: string;
@@ -44,7 +43,7 @@ const LocalStateContext = createContext<LocalStateContextType | undefined>(
 );
 
 const LISTEN_PREFIX_KEY = "clock_listenPrefix";
-const SCREEN_VIEWPORT_KEY = "clock_screenViewport";
+const SCREEN_KEY_KEY = "clock_screenKey";
 
 export function LocalStateProvider({ children }: { children: ReactNode }) {
   // Auth State
@@ -63,20 +62,10 @@ export function LocalStateProvider({ children }: { children: ReactNode }) {
   // Admin state
   const [isAdmin, setIsAdmin] = useState<boolean>(false);
 
-  // Screen viewport override (set when selecting a screen via "Birta skjá")
-  const [screenViewport, setScreenViewportState] = useState<ViewPort | null>(
-    () => {
-      const stored = localStorage.getItem(SCREEN_VIEWPORT_KEY);
-      if (stored) {
-        try {
-          return JSON.parse(stored) as ViewPort;
-        } catch {
-          return null;
-        }
-      }
-      return null;
-    },
-  );
+  // Screen key (set when selecting a screen via "Birta skjá")
+  const [screenKey, setScreenKeyState] = useState<string | null>(() => {
+    return localStorage.getItem(SCREEN_KEY_KEY) || null;
+  });
 
   // Login Form State
   const [email, setEmail] = useState("");
@@ -88,12 +77,12 @@ export function LocalStateProvider({ children }: { children: ReactNode }) {
     localStorage.setItem(LISTEN_PREFIX_KEY, newPrefix);
   };
 
-  const setScreenViewport = (vp: ViewPort | null) => {
-    setScreenViewportState(vp);
-    if (vp) {
-      localStorage.setItem(SCREEN_VIEWPORT_KEY, JSON.stringify(vp));
+  const setScreenKey = (key: string | null) => {
+    setScreenKeyState(key);
+    if (key) {
+      localStorage.setItem(SCREEN_KEY_KEY, key);
     } else {
-      localStorage.removeItem(SCREEN_VIEWPORT_KEY);
+      localStorage.removeItem(SCREEN_KEY_KEY);
     }
   };
 
@@ -159,8 +148,8 @@ export function LocalStateProvider({ children }: { children: ReactNode }) {
     listenPrefix,
     setListenPrefix,
     available,
-    screenViewport,
-    setScreenViewport,
+    screenKey,
+    setScreenKey,
     email,
     setEmail,
     password,

--- a/clock/src/controller/Controller.spec.tsx
+++ b/clock/src/controller/Controller.spec.tsx
@@ -91,8 +91,8 @@ function setupState1() {
     setListenPrefix: vi.fn(),
     auth: { isLoaded: true, isEmpty: true },
     available: null,
-    screenViewport: null,
-    setScreenViewport: vi.fn(),
+    screenKey: null,
+    setScreenKey: vi.fn(),
     isAdmin: false,
   });
   mockedUseRemoteSettings.mockReturnValue({
@@ -126,8 +126,8 @@ function setupState2() {
     setListenPrefix: vi.fn(),
     auth: { isLoaded: true, isEmpty: true },
     available: null,
-    screenViewport: null,
-    setScreenViewport: vi.fn(),
+    screenKey: null,
+    setScreenKey: vi.fn(),
     isAdmin: false,
   });
   mockedUseRemoteSettings.mockReturnValue({
@@ -165,8 +165,8 @@ function setupState3() {
     setListenPrefix: vi.fn(),
     auth: { isLoaded: true, isEmpty: false, email: "test@test.com" },
     available: ["vikinni"],
-    screenViewport: null,
-    setScreenViewport: vi.fn(),
+    screenKey: null,
+    setScreenKey: vi.fn(),
     isAdmin: false,
   });
   mockedUseRemoteSettings.mockReturnValue({
@@ -216,8 +216,8 @@ function setupScreenSelector(
     setListenPrefix: mockSetListenPrefix,
     auth: { isLoaded: true, isEmpty: false, email: "test@test.com" },
     available: mockAvailable,
-    screenViewport: null,
-    setScreenViewport: vi.fn(),
+    screenKey: null,
+    setScreenKey: vi.fn(),
     isAdmin: false,
   });
   mockedUseRemoteSettings.mockReturnValue({

--- a/clock/src/controller/Controller.tsx
+++ b/clock/src/controller/Controller.tsx
@@ -76,7 +76,7 @@ const Controller = () => {
     listenPrefix,
     setListenPrefix,
     available,
-    setScreenViewport,
+    setScreenKey,
   } = useLocalState();
   const auth = useAuth();
   const isAdmin = useIsAdmin();
@@ -145,7 +145,7 @@ const Controller = () => {
                 onClick={() => {
                   const screen = screens[parseInt(selectedScreen, 10)];
                   if (screen) {
-                    setScreenViewport(screen.screen);
+                    setScreenKey(screen.screen.key);
                     setListenPrefix(screen.key);
                   }
                 }}

--- a/clock/src/index.tsx
+++ b/clock/src/index.tsx
@@ -13,14 +13,14 @@ import { AdminRoute } from "./admin/AdminRoute";
 
 // Create a wrapper component that bridges LocalState to FirebaseState
 function AppWithProviders() {
-  const { listenPrefix, auth, screenViewport } = useLocalState();
+  const { listenPrefix, auth, screenKey } = useLocalState();
   const isAuthenticated = auth.isLoaded && !auth.isEmpty;
 
   return (
     <FirebaseStateProvider
       listenPrefix={listenPrefix}
       isAuthenticated={isAuthenticated}
-      screenViewport={screenViewport}
+      screenKey={screenKey}
     >
       <App />
     </FirebaseStateProvider>

--- a/clock/src/match-controller/MatchController.spec.tsx
+++ b/clock/src/match-controller/MatchController.spec.tsx
@@ -11,7 +11,7 @@ const renderWithProviders = (ui: React.ReactElement) => {
       <FirebaseStateProvider
         listenPrefix=""
         isAuthenticated={false}
-        screenViewport={null}
+        screenKey={null}
       >
         {ui}
       </FirebaseStateProvider>

--- a/clock/src/match/Clock.spec.tsx
+++ b/clock/src/match/Clock.spec.tsx
@@ -11,7 +11,7 @@ const renderWithProviders = (component: React.ReactElement) => {
       <FirebaseStateProvider
         listenPrefix=""
         isAuthenticated={false}
-        screenViewport={null}
+        screenKey={null}
       >
         {component}
       </FirebaseStateProvider>

--- a/clock/src/screens/ScoreBoard.spec.tsx
+++ b/clock/src/screens/ScoreBoard.spec.tsx
@@ -12,7 +12,7 @@ const renderWithProviders = () => {
       <FirebaseStateProvider
         listenPrefix=""
         isAuthenticated={false}
-        screenViewport={null}
+        screenKey={null}
       >
         <ScoreBoard />
       </FirebaseStateProvider>
@@ -180,7 +180,7 @@ describe("ScoreBoard component", () => {
           <FirebaseStateProvider
             listenPrefix=""
             isAuthenticated={false}
-            screenViewport={null}
+            screenKey={null}
           >
             <ScoreBoard />
           </FirebaseStateProvider>

--- a/firebase-rules.json
+++ b/firebase-rules.json
@@ -19,7 +19,7 @@
     },
     "locations": {
       ".read": true,
-      ".write": false
+      ".write": "root.child('admins').child(auth.uid).val() == true"
     },
     "states": {
       "$location": {


### PR DESCRIPTION
## Summary
- Replace localStorage-cached `screenViewport` with `screenKey` lookup from live Firebase `locations` data
- When admin changes screen dimensions in Firebase, connected screens update immediately (no disconnect/reconnect needed)
- Add LocationsManager UI to admin portal (`/admin`) for editing venues, screens, pitchIds, and config

## Changes
**Feature 1 — Live viewport sync:**
- `LocalStateContext`: Store only `screenKey` (string) instead of full `ViewPort` object
- `FirebaseStateContext`: `effectiveView` resolves viewport from `listeners.screens` by key
- Screens react to dimension changes in real-time via existing `locations` Firebase subscription

**Feature 2 — Admin screen editor:**
- New `LocationsManager` component in admin portal
- Edit location labels, pitchIds, config (homeTeam, goalScorerBackground)
- Edit screen properties (name, key, fontSize, width, height)
- Add new locations and screens