### PR TITLE
Add flicker reveal effect for goalscorer display

### DIFF
--- a/clock/src/contexts/FirebaseStateContext.tsx
+++ b/clock/src/contexts/FirebaseStateContext.tsx
@@ -199,6 +199,12 @@ interface FirebaseStateContextType {
     goalGifSameImage?: boolean;
     showGoalscorerName?: boolean;
     showGoalscorerNumber?: boolean;
+    flickerInitialOn?: number;
+    flickerInitialOff?: number;
+    flickerOnGrowth?: number;
+    flickerOffDecay?: number;
+    flickerCycles?: number;
+    flickerJitter?: number;
   }) => void;
   setTheme: (theme: ThemeConfig | undefined) => void;
   setThemePreset: (preset: string | undefined) => void;

--- a/clock/src/contexts/firebaseParsers.ts
+++ b/clock/src/contexts/firebaseParsers.ts
@@ -325,6 +325,22 @@ export function parseView(
       typeof raw.showGoalscorerNumber === "boolean"
         ? raw.showGoalscorerNumber
         : undefined,
+    flickerInitialOn:
+      typeof raw.flickerInitialOn === "number"
+        ? raw.flickerInitialOn
+        : undefined,
+    flickerInitialOff:
+      typeof raw.flickerInitialOff === "number"
+        ? raw.flickerInitialOff
+        : undefined,
+    flickerOnGrowth:
+      typeof raw.flickerOnGrowth === "number" ? raw.flickerOnGrowth : undefined,
+    flickerOffDecay:
+      typeof raw.flickerOffDecay === "number" ? raw.flickerOffDecay : undefined,
+    flickerCycles:
+      typeof raw.flickerCycles === "number" ? raw.flickerCycles : undefined,
+    flickerJitter:
+      typeof raw.flickerJitter === "number" ? raw.flickerJitter : undefined,
   };
 }
 

--- a/clock/src/controller/GoalGifSettingsModal.tsx
+++ b/clock/src/controller/GoalGifSettingsModal.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from "react";
-import { Modal, Button, Toggle } from "rsuite";
+import { Modal, Button, Toggle, InputNumber } from "rsuite";
 import { storageHelpers } from "../firebase";
 import { useView } from "../contexts/FirebaseStateContext";
 import { useRemoteSettings } from "../contexts/LocalStateContext";
@@ -254,6 +254,123 @@ const GoalGifSettingsModal: React.FC<GoalGifSettingsModalProps> = ({
               </p>
             </div>
           )}
+
+          <div style={{ borderTop: "1px solid #3c3f43", paddingTop: 16 }}>
+            <label
+              style={{
+                fontWeight: "bold",
+                display: "block",
+                marginBottom: 8,
+              }}
+            >
+              Flicker reveal stillingar
+            </label>
+            <p style={{ fontSize: 12, opacity: 0.7, margin: "0 0 12px" }}>
+              Stýrir blikkandi áhrifum þegar markaskorari birtist
+            </p>
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "1fr 1fr",
+                gap: 12,
+              }}
+            >
+              <label style={{ fontSize: 13 }}>
+                <span style={{ display: "block", marginBottom: 2 }}>
+                  Upphafstími ON (sek)
+                </span>
+                <InputNumber
+                  size="sm"
+                  step={0.01}
+                  min={0.01}
+                  max={2}
+                  value={view.flickerInitialOn ?? 0.03}
+                  onChange={(val) =>
+                    setGoalGifSettings({
+                      flickerInitialOn: Number(val) || 0.03,
+                    })
+                  }
+                />
+              </label>
+              <label style={{ fontSize: 13 }}>
+                <span style={{ display: "block", marginBottom: 2 }}>
+                  Upphafstími OFF (sek)
+                </span>
+                <InputNumber
+                  size="sm"
+                  step={0.01}
+                  min={0.01}
+                  max={2}
+                  value={view.flickerInitialOff ?? 0.4}
+                  onChange={(val) =>
+                    setGoalGifSettings({
+                      flickerInitialOff: Number(val) || 0.4,
+                    })
+                  }
+                />
+              </label>
+              <label style={{ fontSize: 13 }}>
+                <span style={{ display: "block", marginBottom: 2 }}>
+                  ON vöxtur (margfaldari)
+                </span>
+                <InputNumber
+                  size="sm"
+                  step={0.05}
+                  min={1}
+                  max={3}
+                  value={view.flickerOnGrowth ?? 1.2}
+                  onChange={(val) =>
+                    setGoalGifSettings({ flickerOnGrowth: Number(val) || 1.2 })
+                  }
+                />
+              </label>
+              <label style={{ fontSize: 13 }}>
+                <span style={{ display: "block", marginBottom: 2 }}>
+                  OFF minnkun (margfaldari)
+                </span>
+                <InputNumber
+                  size="sm"
+                  step={0.05}
+                  min={0.1}
+                  max={1}
+                  value={view.flickerOffDecay ?? 0.82}
+                  onChange={(val) =>
+                    setGoalGifSettings({ flickerOffDecay: Number(val) || 0.82 })
+                  }
+                />
+              </label>
+              <label style={{ fontSize: 13 }}>
+                <span style={{ display: "block", marginBottom: 2 }}>
+                  Fjöldi hringja
+                </span>
+                <InputNumber
+                  size="sm"
+                  step={1}
+                  min={3}
+                  max={30}
+                  value={view.flickerCycles ?? 16}
+                  onChange={(val) =>
+                    setGoalGifSettings({ flickerCycles: Number(val) || 16 })
+                  }
+                />
+              </label>
+              <label style={{ fontSize: 13 }}>
+                <span style={{ display: "block", marginBottom: 2 }}>
+                  Jitter (handahóf ±%)
+                </span>
+                <InputNumber
+                  size="sm"
+                  step={0.05}
+                  min={0}
+                  max={0.8}
+                  value={view.flickerJitter ?? 0.3}
+                  onChange={(val) =>
+                    setGoalGifSettings({ flickerJitter: Number(val) || 0 })
+                  }
+                />
+              </label>
+            </div>
+          </div>
         </div>
       </Modal.Body>
     </Modal>

--- a/clock/src/controller/asset/Asset.tsx
+++ b/clock/src/controller/asset/Asset.tsx
@@ -341,7 +341,14 @@ const AssetComponent = (props: AssetProps) => {
           includeBackground: false,
         });
         return (
-          <>
+          <div
+            style={{
+              backgroundColor: "black",
+              height: "100%",
+              width: "100%",
+              position: "relative",
+            }}
+          >
             {isVideoUrl(asset.background) ? (
               <video
                 src={asset.background}
@@ -369,7 +376,7 @@ const AssetComponent = (props: AssetProps) => {
             >
               {playerCard}
             </div>
-          </>
+          </div>
         );
       }
       return getPlayerAsset({ asset, widthMultiplier: 1 });

--- a/clock/src/controller/asset/GoalScorerReveal.tsx
+++ b/clock/src/controller/asset/GoalScorerReveal.tsx
@@ -1,0 +1,157 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useState,
+} from "react";
+
+import { useView } from "../../contexts/FirebaseStateContext";
+
+// Default flicker settings — car engine sputtering to life
+const DEFAULTS = {
+  initialOn: 0.03, // seconds
+  initialOff: 0.4, // seconds
+  onGrowth: 1.2, // multiplier per cycle
+  offDecay: 0.82, // multiplier per cycle
+  cycles: 16,
+  jitter: 0.3, // ±30% randomness per step
+};
+
+interface FlickerSettings {
+  initialOn: number;
+  initialOff: number;
+  onGrowth: number;
+  offDecay: number;
+  cycles: number;
+  jitter: number;
+}
+
+// Schedule: [on1, off1, on2, off2, ..., onN] — last entry stays permanent
+function buildSchedule(settings: FlickerSettings): number[] {
+  const schedule: number[] = [];
+  let onDuration = settings.initialOn;
+  let offDuration = settings.initialOff;
+
+  for (let i = 0; i < settings.cycles; i++) {
+    const onJitter = 1 + (Math.random() * 2 - 1) * settings.jitter;
+    const offJitter = 1 + (Math.random() * 2 - 1) * settings.jitter;
+    schedule.push(onDuration * onJitter * 1000);
+    schedule.push(offDuration * offJitter * 1000);
+    onDuration *= settings.onGrowth;
+    offDuration *= settings.offDecay;
+  }
+  schedule.push(onDuration * 1000);
+  return schedule;
+}
+
+interface FlickerState {
+  step: number;
+  revealed: boolean;
+}
+
+type FlickerAction = { type: "advance"; total: number } | { type: "reset" };
+
+function flickerReducer(state: FlickerState, action: FlickerAction) {
+  switch (action.type) {
+    case "advance": {
+      const next = state.step + 1;
+      if (next >= action.total - 1) {
+        return { step: next, revealed: true };
+      }
+      return { step: next, revealed: false };
+    }
+    case "reset":
+      return { step: 0, revealed: false };
+  }
+}
+
+interface GoalScorerRevealProps {
+  children: React.ReactNode;
+  showNameNumber: boolean;
+  nameNumberElement: React.ReactNode;
+}
+
+const GoalScorerReveal: React.FC<GoalScorerRevealProps> = ({
+  children,
+  showNameNumber,
+  nameNumberElement,
+}) => {
+  const {
+    view: {
+      flickerInitialOn,
+      flickerInitialOff,
+      flickerOnGrowth,
+      flickerOffDecay,
+      flickerCycles,
+      flickerJitter,
+    },
+  } = useView();
+
+  const settings: FlickerSettings = useMemo(
+    () => ({
+      initialOn: flickerInitialOn ?? DEFAULTS.initialOn,
+      initialOff: flickerInitialOff ?? DEFAULTS.initialOff,
+      onGrowth: flickerOnGrowth ?? DEFAULTS.onGrowth,
+      offDecay: flickerOffDecay ?? DEFAULTS.offDecay,
+      cycles: flickerCycles ?? DEFAULTS.cycles,
+      jitter: flickerJitter ?? DEFAULTS.jitter,
+    }),
+    [
+      flickerInitialOn,
+      flickerInitialOff,
+      flickerOnGrowth,
+      flickerOffDecay,
+      flickerCycles,
+      flickerJitter,
+    ],
+  );
+
+  const schedule = useMemo(() => buildSchedule(settings), [settings]);
+
+  const [started, setStarted] = useState(false);
+
+  useEffect(() => {
+    const delay = window.setTimeout(() => setStarted(true), 1000);
+    return () => window.clearTimeout(delay);
+  }, []);
+
+  const [state, dispatch] = useReducer(flickerReducer, {
+    step: 0,
+    revealed: false,
+  });
+
+  const advance = useCallback(() => {
+    dispatch({ type: "advance", total: schedule.length });
+  }, [schedule.length]);
+
+  useEffect(() => {
+    dispatch({ type: "reset" });
+  }, [schedule]);
+
+  useEffect(() => {
+    if (state.revealed || !started) return;
+
+    const timeout = window.setTimeout(advance, schedule[state.step]);
+    return () => window.clearTimeout(timeout);
+  }, [state.step, state.revealed, schedule, advance, started]);
+
+  const isVisible = state.revealed || (started && state.step % 2 === 0);
+
+  return (
+    <div style={{ height: "100%", width: "100%", position: "relative" }}>
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+          opacity: isVisible ? 1 : 0,
+        }}
+      >
+        {children}
+      </div>
+      {state.revealed && showNameNumber && nameNumberElement}
+    </div>
+  );
+};
+
+export default GoalScorerReveal;

--- a/clock/src/controller/asset/PlayerCard.tsx
+++ b/clock/src/controller/asset/PlayerCard.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from "react";
 import { DEFAULT_THEME, THUMB_VP, getBackground } from "../../constants";
 import { useView } from "../../contexts/FirebaseStateContext";
 import { resolveTheme } from "../../hooks/useThemeCssVars";
+import GoalScorerReveal from "./GoalScorerReveal";
 
 // Cached canvas for text measurement performance
 let cachedCanvas: HTMLCanvasElement | null = null;
@@ -116,6 +117,41 @@ const PlayerCard = (props: Props): React.JSX.Element => {
     ? (getBackground(background) as React.CSSProperties)
     : {};
   const isGoalCelebration = asset.isGoalCelebration === true;
+
+  const nameNumberElement = (
+    <>
+      {(!isGoalCelebration || showGoalscorerNumber !== false) && (
+        <span className="asset-player-number">
+          {asset.number || (asset.role && asset.role[0])}
+        </span>
+      )}
+      {(!isGoalCelebration || showGoalscorerName !== false) && (
+        <span className="asset-player-name" style={nameStyle}>
+          {asset.name}
+        </span>
+      )}
+    </>
+  );
+
+  if (isGoalCelebration && !thumbnail) {
+    return (
+      <div
+        className={`asset-player-icon ${String(className)}`}
+        key={asset.key}
+        style={style}
+      >
+        <GoalScorerReveal
+          showNameNumber={
+            showGoalscorerName !== false || showGoalscorerNumber !== false
+          }
+          nameNumberElement={nameNumberElement}
+        >
+          {children}
+        </GoalScorerReveal>
+      </div>
+    );
+  }
+
   return (
     <div
       className={`asset-player-icon ${String(className)}`}
@@ -130,16 +166,7 @@ const PlayerCard = (props: Props): React.JSX.Element => {
       >
         {overlay.text}
       </span>
-      {(!isGoalCelebration || showGoalscorerNumber !== false) && (
-        <span className="asset-player-number">
-          {asset.number || (asset.role && asset.role[0])}
-        </span>
-      )}
-      {(!isGoalCelebration || showGoalscorerName !== false) && (
-        <span className="asset-player-name" style={nameStyle}>
-          {asset.name}
-        </span>
-      )}
+      {nameNumberElement}
     </div>
   );
 };

--- a/clock/src/controller/asset/team/TeamAssetController.spec.tsx
+++ b/clock/src/controller/asset/team/TeamAssetController.spec.tsx
@@ -462,26 +462,6 @@ describe("TeamAssetController", () => {
         screen.getByRole("button", { name: "Birta mann leiksins" }),
       ).toBeInTheDocument();
     });
-
-    it("shows effect selector with default blink value", () => {
-      setupMocks({ roster: mockRoster });
-
-      render(<TeamAssetController previousView={mockPreviousView} />);
-
-      const select = screen.getByDisplayValue("Blink");
-      expect(select).toBeInTheDocument();
-    });
-
-    it("allows changing the effect", () => {
-      setupMocks({ roster: mockRoster });
-
-      render(<TeamAssetController previousView={mockPreviousView} />);
-
-      const select = screen.getByDisplayValue("Blink");
-      fireEvent.change(select, { target: { value: "shaker" } });
-
-      expect(screen.getByDisplayValue("Shaker")).toBeInTheDocument();
-    });
   });
 
   describe("substitution flow", () => {
@@ -711,7 +691,7 @@ describe("TeamAssetController", () => {
       ).toBeInTheDocument();
     });
 
-    it("selects goal scorer with overlay effect", async () => {
+    it("selects goal scorer with isGoalCelebration flag", async () => {
       const { mockShowItemNow } = setupMocks({ roster: mockRoster });
 
       const playerAsset = {
@@ -735,7 +715,8 @@ describe("TeamAssetController", () => {
 
       expect(mockedGetPlayerAssetObject).toHaveBeenCalledWith(
         expect.objectContaining({
-          overlay: { text: "", blink: true, effect: "blink" },
+          teamName: "Víkingur R",
+          listenPrefix: "vikinni",
         }),
       );
       await waitFor(() => {
@@ -744,30 +725,6 @@ describe("TeamAssetController", () => {
           isGoalCelebration: true,
         });
       });
-    });
-
-    it("uses selected effect for goal scorer overlay", () => {
-      setupMocks({ roster: mockRoster });
-
-      mockedGetPlayerAssetObject.mockResolvedValue(
-        {} as unknown as Awaited<ReturnType<typeof getPlayerAssetObject>>,
-      );
-
-      render(<TeamAssetController previousView={mockPreviousView} />);
-
-      const select = screen.getByDisplayValue("Blink");
-      fireEvent.change(select, { target: { value: "shaker" } });
-
-      fireEvent.click(
-        screen.getByRole("button", { name: "Birta markaskorara" }),
-      );
-      fireEvent.click(screen.getByTestId("select-player-homeTeam"));
-
-      expect(mockedGetPlayerAssetObject).toHaveBeenCalledWith(
-        expect.objectContaining({
-          overlay: { text: "", blink: true, effect: "shaker" },
-        }),
-      );
     });
   });
 

--- a/clock/src/controller/asset/team/TeamAssetController.tsx
+++ b/clock/src/controller/asset/team/TeamAssetController.tsx
@@ -50,7 +50,6 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
   const [selectPlayerAsset, setSelectPlayerAsset] = useState(false);
   const [selectGoalScorer, setSelectGoalScorer] = useState(false);
   const [selectMOTM, setSelectMOTM] = useState(false);
-  const [effect, setEffect] = useState("blink");
 
   const refetchRoster = (): void => {
     if (!match.ksiMatchId) return;
@@ -175,11 +174,6 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
       const goalAsset = await getPlayerAssetObject({
         player,
         teamName: actualTeamName,
-        overlay: {
-          text: "",
-          blink: true,
-          effect: effect,
-        },
         listenPrefix,
       });
       if (!goalAsset) return;
@@ -278,15 +272,6 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
                 Birta mann leiksins
               </button>
             </div>
-            <select
-              className="effect-select"
-              onChange={({ target: { value } }) => setEffect(value)}
-              value={effect}
-            >
-              <option value="blink">Blink</option>
-              <option value="shaker">Shaker</option>
-              <option value="scaleit">Scale Up</option>
-            </select>
           </>
         )}
       </div>

--- a/clock/src/types.ts
+++ b/clock/src/types.ts
@@ -236,6 +236,12 @@ export interface ViewState {
   goalGifSameImage?: boolean;
   showGoalscorerName?: boolean;
   showGoalscorerNumber?: boolean;
+  flickerInitialOn?: number;
+  flickerInitialOff?: number;
+  flickerOnGrowth?: number;
+  flickerOffDecay?: number;
+  flickerCycles?: number;
+  flickerJitter?: number;
 }
 
 // Remote state type


### PR DESCRIPTION
## Summary

- Replaces old blink/shaker/scaleit overlay effects with a new **flicker reveal** animation for goalscorer display
- Player image sputters to life (short on → long off, gradually inverting) with configurable random jitter for organic feel
- Name/number only appears after the reveal animation completes
- 1-second delay before animation starts to let background media load
- Black background on player asset container prevents scoreboard bleed-through during media loading

## Settings (configurable in "Heimalið mark stillingar")

| Parameter | Default | Description |
|-----------|---------|-------------|
| Initial ON | 0.03s | Starting visible duration |
| Initial OFF | 0.4s | Starting hidden duration |
| ON growth | 1.2× | Multiplier each cycle |
| OFF decay | 0.82× | Multiplier each cycle |
| Cycles | 16 | Total on/off cycles |
| Jitter | ±30% | Random variation per step |

Born from #173