### PR TITLE
Add uploadable home team reveal background

### DIFF
--- a/clock/src/contexts/FirebaseStateContext.tsx
+++ b/clock/src/contexts/FirebaseStateContext.tsx
@@ -205,6 +205,7 @@ interface FirebaseStateContextType {
     flickerOffDecay?: number;
     flickerCycles?: number;
     flickerJitter?: number;
+    homeTeamRevealBackground?: string | null;
   }) => void;
   setTheme: (theme: ThemeConfig | undefined) => void;
   setThemePreset: (preset: string | undefined) => void;

--- a/clock/src/contexts/firebaseParsers.ts
+++ b/clock/src/contexts/firebaseParsers.ts
@@ -341,6 +341,12 @@ export function parseView(
       typeof raw.flickerCycles === "number" ? raw.flickerCycles : undefined,
     flickerJitter:
       typeof raw.flickerJitter === "number" ? raw.flickerJitter : undefined,
+    homeTeamRevealBackground:
+      typeof raw.homeTeamRevealBackground === "string"
+        ? raw.homeTeamRevealBackground
+        : raw.homeTeamRevealBackground === null
+          ? null
+          : undefined,
   };
 }
 

--- a/clock/src/controller/Controller.tsx
+++ b/clock/src/controller/Controller.tsx
@@ -43,7 +43,7 @@ import { firebaseAuth } from "../firebaseAuth";
 import MatchActionSettings from "./MatchActionSettings";
 import ThemeEditorModal from "./theme/ThemeEditor";
 import ClubOverrideList from "./ClubOverrideList";
-import GoalGifSettingsModal from "./GoalGifSettingsModal";
+import HomeTeamSettingsModal from "./HomeTeamSettingsModal";
 import MediaManager from "./media/MediaManager";
 import RefreshHandler from "./RefreshHandler";
 import AssetController from "./asset/AssetController";
@@ -370,12 +370,12 @@ const Controller = () => {
               Opna
             </Button>
           </div>
-          <div className="theme-trigger-row">
-            <div className="theme-trigger-info">
-              <span className="theme-trigger-label">
-                Heimalið mark stillingar
-              </span>
-            </div>
+           <div className="theme-trigger-row">
+             <div className="theme-trigger-info">
+               <span className="theme-trigger-label">
+                 Heimalið stillingar
+               </span>
+             </div>
             <Button
               size="sm"
               appearance="primary"
@@ -410,7 +410,7 @@ const Controller = () => {
         open={overrideListOpen}
         onClose={() => setOverrideListOpen(false)}
       />
-      <GoalGifSettingsModal
+      <HomeTeamSettingsModal
         open={goalGifOpen}
         onClose={() => setGoalGifOpen(false)}
       />

--- a/clock/src/controller/Controller.tsx
+++ b/clock/src/controller/Controller.tsx
@@ -370,12 +370,10 @@ const Controller = () => {
               Opna
             </Button>
           </div>
-           <div className="theme-trigger-row">
-             <div className="theme-trigger-info">
-               <span className="theme-trigger-label">
-                 Heimalið stillingar
-               </span>
-             </div>
+          <div className="theme-trigger-row">
+            <div className="theme-trigger-info">
+              <span className="theme-trigger-label">Heimalið stillingar</span>
+            </div>
             <Button
               size="sm"
               appearance="primary"

--- a/clock/src/controller/HomeTeamSettingsModal.tsx
+++ b/clock/src/controller/HomeTeamSettingsModal.tsx
@@ -288,23 +288,39 @@ const HomeTeamSettingsModal: React.FC<HomeTeamSettingsModalProps> = ({
             <p style={{ fontSize: 12, opacity: 0.7, margin: "0 0 8px" }}>
               Birtist á bak við leikmann í liðskynningu, skiptingum og MOTM
             </p>
-            {view.homeTeamRevealBackground && (
-              <img
-                src={view.homeTeamRevealBackground}
-                alt="Reveal background"
-                style={{
-                  maxWidth: 200,
-                  maxHeight: 120,
-                  display: "block",
-                  marginBottom: 8,
-                  borderRadius: 4,
-                }}
-              />
-            )}
+            {view.homeTeamRevealBackground &&
+              (isVideoUrl(view.homeTeamRevealBackground) ? (
+                <video
+                  src={view.homeTeamRevealBackground}
+                  autoPlay
+                  loop
+                  muted
+                  playsInline
+                  style={{
+                    maxWidth: 200,
+                    maxHeight: 120,
+                    display: "block",
+                    marginBottom: 8,
+                    borderRadius: 4,
+                  }}
+                />
+              ) : (
+                <img
+                  src={view.homeTeamRevealBackground}
+                  alt="Reveal background"
+                  style={{
+                    maxWidth: 200,
+                    maxHeight: 120,
+                    display: "block",
+                    marginBottom: 8,
+                    borderRadius: 4,
+                  }}
+                />
+              ))}
             <input
               ref={revealBgRef}
               type="file"
-              accept="image/*"
+              accept="image/gif,image/*,video/mp4,video/webm"
               style={{ display: "none" }}
               onChange={handleRevealBgChange}
             />
@@ -329,7 +345,7 @@ const HomeTeamSettingsModal: React.FC<HomeTeamSettingsModalProps> = ({
               )}
             </div>
             <p style={{ fontSize: 11, opacity: 0.5, margin: "4px 0 0" }}>
-              PNG, JPG, WebP
+              PNG, JPG, GIF, MP4, WebM
             </p>
           </div>
 

--- a/clock/src/controller/HomeTeamSettingsModal.tsx
+++ b/clock/src/controller/HomeTeamSettingsModal.tsx
@@ -14,12 +14,12 @@ const buildGoalMediaPath = (
   return `${listenPrefix}/goal-media/${slot}-${Date.now()}.${ext}`;
 };
 
-interface GoalGifSettingsModalProps {
+interface HomeTeamSettingsModalProps {
   open: boolean;
   onClose: () => void;
 }
 
-const GoalGifSettingsModal: React.FC<GoalGifSettingsModalProps> = ({
+const HomeTeamSettingsModal: React.FC<HomeTeamSettingsModalProps> = ({
   open,
   onClose,
 }) => {
@@ -27,6 +27,7 @@ const GoalGifSettingsModal: React.FC<GoalGifSettingsModalProps> = ({
   const { listenPrefix } = useRemoteSettings();
   const gif1Ref = useRef<HTMLInputElement>(null);
   const gif2Ref = useRef<HTMLInputElement>(null);
+  const revealBgRef = useRef<HTMLInputElement>(null);
 
   const uploadMedia = async (file: File, slot: "goalGif1" | "goalGif2") => {
     const path = buildGoalMediaPath(listenPrefix, slot, file.name);
@@ -48,10 +49,29 @@ const GoalGifSettingsModal: React.FC<GoalGifSettingsModalProps> = ({
       e.target.value = "";
     };
 
+  const uploadRevealBackground = async (file: File) => {
+    const ext = file.name.split(".").pop() || "png";
+    const path = `${listenPrefix}/goal-media/reveal-bg-${Date.now()}.${ext}`;
+    await storageHelpers.uploadBytes(path, file, {
+      cacheControl: "public, max-age=31536000",
+      contentType: file.type,
+    });
+    const url = await storageHelpers.getDownloadURL(path);
+    setGoalGifSettings({ homeTeamRevealBackground: url });
+  };
+
+  const handleRevealBgChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      void uploadRevealBackground(file);
+    }
+    e.target.value = "";
+  };
+
   return (
     <Modal open={open} onClose={onClose} size="sm">
       <Modal.Header>
-        <Modal.Title>Heimalið mark stillingar</Modal.Title>
+        <Modal.Title>Heimalið stillingar</Modal.Title>
       </Modal.Header>
       <Modal.Body>
         <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
@@ -260,6 +280,64 @@ const GoalGifSettingsModal: React.FC<GoalGifSettingsModalProps> = ({
               style={{
                 fontWeight: "bold",
                 display: "block",
+                marginBottom: 4,
+              }}
+            >
+              Leikmanna bakgrunnur
+            </label>
+            <p style={{ fontSize: 12, opacity: 0.7, margin: "0 0 8px" }}>
+              Birtist á bak við leikmann í liðskynningu, skiptingum og MOTM
+            </p>
+            {view.homeTeamRevealBackground && (
+              <img
+                src={view.homeTeamRevealBackground}
+                alt="Reveal background"
+                style={{
+                  maxWidth: 200,
+                  maxHeight: 120,
+                  display: "block",
+                  marginBottom: 8,
+                  borderRadius: 4,
+                }}
+              />
+            )}
+            <input
+              ref={revealBgRef}
+              type="file"
+              accept="image/*"
+              style={{ display: "none" }}
+              onChange={handleRevealBgChange}
+            />
+            <div style={{ display: "flex", gap: 8 }}>
+              <Button
+                size="sm"
+                appearance="primary"
+                onClick={() => revealBgRef.current?.click()}
+              >
+                Hlaða upp
+              </Button>
+              {view.homeTeamRevealBackground && (
+                <Button
+                  size="sm"
+                  appearance="ghost"
+                  onClick={() =>
+                    setGoalGifSettings({ homeTeamRevealBackground: null })
+                  }
+                >
+                  Fjarlægja
+                </Button>
+              )}
+            </div>
+            <p style={{ fontSize: 11, opacity: 0.5, margin: "4px 0 0" }}>
+              PNG, JPG, WebP
+            </p>
+          </div>
+
+          <div style={{ borderTop: "1px solid #3c3f43", paddingTop: 16 }}>
+            <label
+              style={{
+                fontWeight: "bold",
+                display: "block",
                 marginBottom: 8,
               }}
             >
@@ -377,4 +455,4 @@ const GoalGifSettingsModal: React.FC<GoalGifSettingsModalProps> = ({
   );
 };
 
-export default GoalGifSettingsModal;
+export default HomeTeamSettingsModal;

--- a/clock/src/controller/asset/Asset.tsx
+++ b/clock/src/controller/asset/Asset.tsx
@@ -199,7 +199,17 @@ const AssetComponent = (props: AssetProps) => {
           includeBackground={includeBackground}
         >
           {includeBackground !== false && playerAsset.background ? (
-            <img src={playerAsset.background} alt={playerAsset.background} />
+            isVideoUrl(playerAsset.background) ? (
+              <video
+                src={playerAsset.background}
+                autoPlay
+                loop
+                muted
+                playsInline
+              />
+            ) : (
+              <img src={playerAsset.background} alt={playerAsset.background} />
+            )
           ) : null}
           <img src={playerAsset.key} alt={playerAsset.key} />
         </PlayerCard>
@@ -218,7 +228,17 @@ const AssetComponent = (props: AssetProps) => {
           includeBackground={includeBackground}
         >
           {includeBackground !== false && playerAsset.background ? (
-            <img src={playerAsset.background} alt={playerAsset.background} />
+            isVideoUrl(playerAsset.background) ? (
+              <video
+                src={playerAsset.background}
+                autoPlay
+                loop
+                muted
+                playsInline
+              />
+            ) : (
+              <img src={playerAsset.background} alt={playerAsset.background} />
+            )
           ) : null}
           {teamName && teamLogoUrl ? (
             <img src={teamLogoUrl} alt={teamName} />

--- a/clock/src/controller/asset/team/TeamAssetController.spec.tsx
+++ b/clock/src/controller/asset/team/TeamAssetController.spec.tsx
@@ -14,6 +14,7 @@ import {
   useController,
   useMatch,
   useListeners,
+  useView,
 } from "../../../contexts/FirebaseStateContext";
 import { useRemoteSettings } from "../../../contexts/LocalStateContext";
 import { transformLineups, getTeamId } from "../../../lib/matchUtils";
@@ -23,6 +24,7 @@ vi.mock("../../../contexts/FirebaseStateContext", () => ({
   useMatch: vi.fn(),
   useController: vi.fn(),
   useListeners: vi.fn(),
+  useView: vi.fn(),
 }));
 
 vi.mock("../../../contexts/LocalStateContext", () => ({
@@ -103,6 +105,7 @@ import { getPlayerAssetObject, getMOTMAsset } from "./assetHelpers";
 const mockedUseMatch = vi.mocked(useMatch);
 const mockedUseController = vi.mocked(useController);
 const mockedUseListeners = vi.mocked(useListeners);
+const mockedUseView = vi.mocked(useView);
 const mockedUseRemoteSettings = vi.mocked(useRemoteSettings);
 const mockedGetLineups = vi.mocked(getLineups);
 const mockedTransformLineups = vi.mocked(transformLineups);
@@ -203,6 +206,11 @@ function setupMocks(overrides?: {
   mockedUseListeners.mockReturnValue({
     screens: [{ key: "vikinni", teamId: 2492 }],
   } as unknown as ReturnType<typeof useListeners>);
+
+  mockedUseView.mockReturnValue({
+    view: {},
+    setGoalGifSettings: vi.fn(),
+  } as unknown as ReturnType<typeof useView>);
 
   mockedGetTeamId.mockReturnValue(2492);
 

--- a/clock/src/controller/asset/team/TeamAssetController.tsx
+++ b/clock/src/controller/asset/team/TeamAssetController.tsx
@@ -11,6 +11,7 @@ import {
   useController,
   useMatch,
   useListeners,
+  useView,
 } from "../../../contexts/FirebaseStateContext";
 import { useRemoteSettings } from "../../../contexts/LocalStateContext";
 import "../../../api/clientConfig";
@@ -39,6 +40,7 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
   } = useController();
   const { roster } = controller;
   const { screens } = useListeners();
+  const { view } = useView();
   const { listenPrefix } = useRemoteSettings();
 
   const [loading, setLoading] = useState(false);
@@ -106,7 +108,12 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
 
     const resolved = await Promise.all(assetPromises);
     const validAssets: Asset[] = resolved.filter((a) => a !== null);
-    addItemsToQueue(newQueueId, validAssets);
+    const homeRevealBg = view.homeTeamRevealBackground;
+    const assetsWithBg =
+      side === "home" && homeRevealBg
+        ? validAssets.map((a) => ({ ...a, background: homeRevealBg }))
+        : validAssets;
+    addItemsToQueue(newQueueId, assetsWithBg);
 
     previousView();
   };
@@ -138,10 +145,20 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
           listenPrefix,
         });
         if (!subInObj || !subOutObj) return;
+        const homeRevealBg = view.homeTeamRevealBackground;
+        const isHome = subIn.teamName === "homeTeam";
+        const finalSubIn =
+          isHome && homeRevealBg
+            ? { ...subInObj, background: homeRevealBg }
+            : subInObj;
+        const finalSubOut =
+          isHome && homeRevealBg
+            ? { ...subOutObj, background: homeRevealBg }
+            : subOutObj;
         showItemNow({
           type: assetTypes.SUB,
-          subIn: subInObj,
-          subOut: subOutObj,
+          subIn: finalSubIn,
+          subOut: finalSubOut,
           key: `sub-${subInObj.key}-${subOutObj.key}`,
         });
         clearState();
@@ -162,7 +179,12 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
         listenPrefix,
       });
       if (!playerAsset) return;
-      showItemNow(playerAsset);
+      const homeRevealBg = view.homeTeamRevealBackground;
+      const assetWithBg =
+        teamName === "homeTeam" && homeRevealBg
+          ? { ...playerAsset, background: homeRevealBg }
+          : playerAsset;
+      showItemNow(assetWithBg);
       clearState();
     })();
   };
@@ -192,7 +214,12 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
         listenPrefix,
       });
       if (!motmAsset) return;
-      showItemNow(motmAsset);
+      const homeRevealBg = view.homeTeamRevealBackground;
+      const assetWithBg =
+        teamName === "homeTeam" && homeRevealBg
+          ? { ...motmAsset, background: homeRevealBg }
+          : motmAsset;
+      showItemNow(assetWithBg);
       clearState();
     })();
   };

--- a/clock/src/types.ts
+++ b/clock/src/types.ts
@@ -242,6 +242,7 @@ export interface ViewState {
   flickerOffDecay?: number;
   flickerCycles?: number;
   flickerJitter?: number;
+  homeTeamRevealBackground?: string | null;
 }
 
 // Remote state type


### PR DESCRIPTION
## Summary
- Adds a `homeTeamRevealBackground` image upload in the "Heimalið stillingar" modal (renamed from "Heimalið mark stillingar")
- When uploaded, this background appears behind home team players in: lineup queue reveal, substitutions, and MOTM displays
- Goal celebrations are NOT affected (those use goalGif1/goalGif2)
- Renames `GoalGifSettingsModal` → `HomeTeamSettingsModal` (file + component)