### PR TITLE
Move extra time input out of tímastjórnun modal

### DIFF
--- a/.opencode/skills/deploy-staging/SKILL.md
+++ b/.opencode/skills/deploy-staging/SKILL.md
@@ -100,3 +100,19 @@ Summarize:
 - The staging environment shares nothing with production — safe to deploy freely.
 - CloudFront caches aggressively; without invalidation, changes may take up to 24h to appear.
 - Only `/index.html` is invalidated because asset files are content-hashed (unique filenames on each build).
+
+## Uploading screenshots for PRs
+
+GitHub doesn't support programmatic image uploads to PR comments. Use the staging S3 bucket instead:
+
+```bash
+source /home/dev/vikes-creds.txt
+aws s3 cp screenshot.png "s3://$STAGING_BUCKET/pr-images/<ISSUE_NUMBER>-<descriptive-name>.png" --region eu-west-1
+```
+
+Then reference in PR/comment markdown:
+```
+![Description](https://staging-klukka.irdn.is/pr-images/<ISSUE_NUMBER>-<descriptive-name>.png)
+```
+
+These images are served via CloudFront and don't need invalidation (unique paths). They persist until the next `aws s3 rm --recursive` deploy, so use descriptive names with issue numbers. They are disposable — losing them on next deploy is fine since PRs are already merged by then.

--- a/.opencode/skills/deploy-staging/SKILL.md
+++ b/.opencode/skills/deploy-staging/SKILL.md
@@ -59,11 +59,11 @@ Verify the `clock/build/` directory exists and contains `index.html`.
 
 ```bash
 source /home/dev/vikes-creds.txt
-aws s3 rm "s3://$STAGING_BUCKET" --recursive --region eu-west-1
+aws s3 rm "s3://$STAGING_BUCKET" --recursive --exclude "pr-images/*" --region eu-west-1
 aws s3 cp clock/build/ "s3://$STAGING_BUCKET" --recursive --region eu-west-1
 ```
 
-The `rm --recursive` first ensures deleted files are removed. Then `cp --recursive` uploads every file unconditionally.
+The `rm --recursive` first ensures deleted files are removed. The `--exclude "pr-images/*"` preserves PR screenshot uploads. Then `cp --recursive` uploads every file unconditionally.
 
 ### 6. Invalidate CloudFront and wait
 
@@ -115,4 +115,4 @@ Then reference in PR/comment markdown:
 ![Description](https://staging-klukka.irdn.is/pr-images/<ISSUE_NUMBER>-<descriptive-name>.png)
 ```
 
-These images are served via CloudFront and don't need invalidation (unique paths). They persist until the next `aws s3 rm --recursive` deploy, so use descriptive names with issue numbers. They are disposable — losing them on next deploy is fine since PRs are already merged by then.
+These images are served via CloudFront and don't need invalidation (unique paths). The `pr-images/` prefix is excluded from `aws s3 rm` during deploys, so these images persist across deployments.

--- a/.opencode/skills/deploy-staging/SKILL.md
+++ b/.opencode/skills/deploy-staging/SKILL.md
@@ -107,12 +107,15 @@ GitHub doesn't support programmatic image uploads to PR comments. Use the stagin
 
 ```bash
 source /home/dev/vikes-creds.txt
-aws s3 cp screenshot.png "s3://$STAGING_BUCKET/pr-images/<ISSUE_NUMBER>-<descriptive-name>.png" --region eu-west-1
+TIMESTAMP=$(date +%s)
+aws s3 cp screenshot.png "s3://$STAGING_BUCKET/pr-images/<ISSUE_NUMBER>-<descriptive-name>-${TIMESTAMP}.png" --region eu-west-1
 ```
 
 Then reference in PR/comment markdown:
 ```
-![Description](https://staging-klukka.irdn.is/pr-images/<ISSUE_NUMBER>-<descriptive-name>.png)
+![Description](https://staging-klukka.irdn.is/pr-images/<ISSUE_NUMBER>-<descriptive-name>-<TIMESTAMP>.png)
 ```
+
+**IMPORTANT: CloudFront caches aggressively.** If you reuse the same filename for an updated screenshot, CloudFront will serve the old cached version. Always include a timestamp or unique suffix in the filename to bust the cache. Never reuse a previous screenshot path when updating an image.
 
 These images are served via CloudFront and don't need invalidation (unique paths). The `pr-images/` prefix is excluded from `aws s3 rm` during deploys, so these images persist across deployments.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,4 +103,5 @@ The match data pipeline depends on team IDs matching between the frontend and th
 ### E2E Tests
 - Playwright for browser automation
 - `TEST_CREDENTIALS` env var for authentication (format: `EMAIL;PASSWORD`)
+- **Credentials location**: The main worktree at `/home/dev/vikes-match-clock/.envrc-local` contains `TEST_CREDENTIALS` for staging login. Source this file or extract the email/password from it.
 - Multi-session testing requires manual testing or Playwright test runner (Playwright MCP limitations)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,5 +103,5 @@ The match data pipeline depends on team IDs matching between the frontend and th
 ### E2E Tests
 - Playwright for browser automation
 - `TEST_CREDENTIALS` env var for authentication (format: `EMAIL;PASSWORD`)
-- **Credentials location**: The main worktree at `/home/dev/vikes-match-clock/.envrc-local` contains `TEST_CREDENTIALS` for staging login. Source this file or extract the email/password from it.
+- **Credentials location**: The main worktree's `.envrc-local` contains `TEST_CREDENTIALS` for staging login. Source this file or extract the email/password from it.
 - Multi-session testing requires manual testing or Playwright test runner (Playwright MCP limitations)

--- a/clock/src/controller/MatchActions.tsx
+++ b/clock/src/controller/MatchActions.tsx
@@ -204,19 +204,20 @@ const MatchActions = () => {
         </div>
       </div>
 
-      {match.matchType === Sports.Football && (
-        <input
-          type="number"
-          className="longerInput"
-          placeholder="Uppbót (mín)"
-          value={match.injuryTime || ""}
-          onChange={({ target: { value } }) =>
-            updateMatch({ injuryTime: parseInt(value, 10) })
-          }
-        />
-      )}
-
-      <RedCardManipulation />
+      <div className="match-actions-clock-secondary">
+        <RedCardManipulation />
+        {match.matchType === Sports.Football && (
+          <input
+            type="number"
+            className="longerInput"
+            placeholder="Uppbót (mín)"
+            value={match.injuryTime || ""}
+            onChange={({ target: { value } }) =>
+              updateMatch({ injuryTime: parseInt(value, 10) })
+            }
+          />
+        )}
+      </div>
 
       {match.matchType === Sports.Handball ? (
         <div className="match-actions-handball">

--- a/clock/src/controller/MatchActions.tsx
+++ b/clock/src/controller/MatchActions.tsx
@@ -204,8 +204,6 @@ const MatchActions = () => {
         </div>
       </div>
 
-      <RedCardManipulation />
-
       {match.matchType === Sports.Football && (
         <input
           type="number"
@@ -217,6 +215,8 @@ const MatchActions = () => {
           }
         />
       )}
+
+      <RedCardManipulation />
 
       {match.matchType === Sports.Handball ? (
         <div className="match-actions-handball">

--- a/clock/src/controller/MatchActions.tsx
+++ b/clock/src/controller/MatchActions.tsx
@@ -201,21 +201,22 @@ const MatchActions = () => {
           <Button size="xs" onClick={() => setShowTimeDialog(true)}>
             <TimeIcon /> Tímastjórnun
           </Button>
-          {match.matchType === Sports.Football && (
-            <input
-              type="number"
-              className="longerInput"
-              placeholder="Uppbót (mín)"
-              value={match.injuryTime || ""}
-              onChange={({ target: { value } }) =>
-                updateMatch({ injuryTime: parseInt(value, 10) })
-              }
-            />
-          )}
         </div>
       </div>
 
       <RedCardManipulation />
+
+      {match.matchType === Sports.Football && (
+        <input
+          type="number"
+          className="longerInput"
+          placeholder="Uppbót (mín)"
+          value={match.injuryTime || ""}
+          onChange={({ target: { value } }) =>
+            updateMatch({ injuryTime: parseInt(value, 10) })
+          }
+        />
+      )}
 
       {match.matchType === Sports.Handball ? (
         <div className="match-actions-handball">

--- a/clock/src/controller/MatchActions.tsx
+++ b/clock/src/controller/MatchActions.tsx
@@ -96,20 +96,6 @@ const TimeControlDialog = ({
             );
           })}
         </div>
-        {match.matchType === Sports.Football ? (
-          <div className="time-control-section">
-            <label className="time-control-label">Uppbótartími</label>
-            <input
-              type="number"
-              className="longerInput"
-              placeholder="Mín"
-              value={match.injuryTime || ""}
-              onChange={({ target: { value } }) =>
-                updateMatch({ injuryTime: parseInt(value, 10) })
-              }
-            />
-          </div>
-        ) : null}
         {match.matchType === Sports.Handball ? (
           <div className="time-control-section-penalties">
             <PenaltiesManipulationBox team="home" />
@@ -215,6 +201,17 @@ const MatchActions = () => {
           <Button size="xs" onClick={() => setShowTimeDialog(true)}>
             <TimeIcon /> Tímastjórnun
           </Button>
+          {match.matchType === Sports.Football && (
+            <input
+              type="number"
+              className="longerInput"
+              placeholder="Uppbót (mín)"
+              value={match.injuryTime || ""}
+              onChange={({ target: { value } }) =>
+                updateMatch({ injuryTime: parseInt(value, 10) })
+              }
+            />
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- Moves the injury time (uppbót) number input from inside the Tímastjórnun modal to the main match actions area, on the same row as the Rauð spjöld button
- Football-only; handball UI unchanged. Modal retains time adjustment buttons and handball penalties.

Closes #176

## Screenshots (staging)

Empty input:

![Empty extra time input](https://staging-klukka.irdn.is/pr-images/176-uppbot-empty-1778279750.png)

With value:

![Extra time input with value](https://staging-klukka.irdn.is/pr-images/176-uppbot-with-value-1778279750.png)

Staging: https://staging-klukka.irdn.is