### PR TITLE
fix: pin preview font sizes to defaults (#178)

### DIFF
--- a/clock/src/App.tsx
+++ b/clock/src/App.tsx
@@ -21,7 +21,7 @@ import GoalScorerDialog from "./controller/GoalScorerDialog";
 import ScoreBoard from "./screens/ScoreBoard";
 import Idle from "./screens/Idle";
 
-import { VIEWS, Sports, getBackground } from "./constants";
+import { VIEWS, Sports, getBackground, DEFAULT_THEME } from "./constants";
 import MatchController from "./match-controller/MatchController";
 import useGlobalShortcuts from "./hooks/useGlobalShortcuts";
 import useNightBlackout from "./hooks/useNightBlackout";
@@ -250,6 +250,17 @@ function App() {
     ...themeCssVars,
   };
 
+  // Static font-size overrides for the controller preview so that theme
+  // font-size edits don't break the small preview layout (issue #178).
+  // Font-family settings still apply — only sizes are pinned.
+  const previewFontSizeOverrides: React.CSSProperties = {
+    "--theme-score-font-size": DEFAULT_THEME.scoreBoxFontSize,
+    "--theme-clock-font-size-min": DEFAULT_THEME.clockFontSizeMin,
+    "--theme-clock-font-size-max": DEFAULT_THEME.clockFontSizeMax,
+    "--theme-injury-font-size": DEFAULT_THEME.injuryTimeFontSize,
+    "--theme-idle-text-font-size": DEFAULT_THEME.idleTextFontSize,
+  } as React.CSSProperties;
+
   // State 2: listenPrefix set, not authenticated — display screen + disconnect button only
   if (!isAuthenticated) {
     return (
@@ -325,6 +336,7 @@ function App() {
                     className="App"
                     style={{
                       ...style,
+                      ...previewFontSizeOverrides,
                       transform: `scale(${previewScale})`,
                       transformOrigin: "top left",
                     }}


### PR DESCRIPTION
## Summary

- Override font-size CSS variables with `DEFAULT_THEME` values in the controller sidebar preview, so that theme font-size edits don't break the small preview layout
- Font-family settings still apply in the preview — only sizes are pinned to defaults
- `overflow: hidden` was already present on `.scoreboard-preview`

Fixes #178

## What changed

In `clock/src/App.tsx`:
1. Import `DEFAULT_THEME` from constants
2. Create `previewFontSizeOverrides` that pins `--theme-score-font-size`, `--theme-clock-font-size-min`, `--theme-clock-font-size-max`, `--theme-injury-font-size`, and `--theme-idle-text-font-size` to their default values
3. Spread these overrides onto the preview `.App` div's style (after `...style`, before `transform`)

## Validation

Deployed to staging (https://staging-klukka.irdn.is) and verified:
- Set score font size to 8rem, clock font sizes to 6-7rem (extreme values)
- Preview remained properly contained with no overflow
- Full-size display correctly shows the large fonts as intended