### PR TITLE
Fix Birta markaskorara to use goal cycle background

### DIFF
--- a/clock/src/App.tsx
+++ b/clock/src/App.tsx
@@ -28,7 +28,7 @@ import useNightBlackout from "./hooks/useNightBlackout";
 import useScreenPresence from "./hooks/useScreenPresence";
 import { useThemeCssVars, resolveTheme } from "./hooks/useThemeCssVars";
 import assetTypes from "./controller/asset/AssetTypes";
-import { isVideoUrl } from "./utils/matchUtils";
+import { isVideoUrl, resolveGoalBackground } from "./utils/matchUtils";
 
 import "./App.css";
 
@@ -86,11 +86,7 @@ const ScoreButtons = ({ side }: { side: "home" | "away" }) => {
         open={scorerDialogOpen}
         players={players}
         teamName={teamName}
-        goalGif2={
-          view.goalGifSameImage || !view.goalGif2
-            ? view.goalGif1
-            : view.goalGif2
-        }
+        goalGif2={resolveGoalBackground(view)}
         onClose={() => setScorerDialogOpen(false)}
       />
     </div>

--- a/clock/src/controller/GoalScorerDialog.tsx
+++ b/clock/src/controller/GoalScorerDialog.tsx
@@ -4,25 +4,8 @@ import { Player } from "../types";
 import { getPlayerAssetObject } from "./asset/team/assetHelpers";
 import { useController } from "../contexts/FirebaseStateContext";
 import { useRemoteSettings } from "../contexts/LocalStateContext";
-import { isVideoUrl } from "../utils/matchUtils";
+import { preloadMedia } from "../utils/matchUtils";
 
-function preloadMedia(url: string): Promise<void> {
-  if (isVideoUrl(url)) {
-    return new Promise((resolve) => {
-      const video = document.createElement("video");
-      video.preload = "auto";
-      video.oncanplaythrough = () => resolve();
-      video.onerror = () => resolve();
-      video.src = url;
-    });
-  }
-  return new Promise((resolve) => {
-    const img = new Image();
-    img.onload = () => resolve();
-    img.onerror = () => resolve();
-    img.src = url;
-  });
-}
 interface GoalScorerDialogProps {
   open: boolean;
   players: Player[];

--- a/clock/src/controller/asset/team/TeamAssetController.spec.tsx
+++ b/clock/src/controller/asset/team/TeamAssetController.spec.tsx
@@ -40,15 +40,6 @@ vi.mock("../../../lib/matchUtils", () => ({
   getTeamId: vi.fn(),
 }));
 
-vi.mock("../../../utils/matchUtils", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("../../../utils/matchUtils")>();
-  return {
-    ...actual,
-    preloadMedia: vi.fn().mockResolvedValue(undefined),
-  };
-});
-
 vi.mock("./Team", () => ({
   default: ({
     teamName,

--- a/clock/src/controller/asset/team/TeamAssetController.spec.tsx
+++ b/clock/src/controller/asset/team/TeamAssetController.spec.tsx
@@ -40,6 +40,15 @@ vi.mock("../../../lib/matchUtils", () => ({
   getTeamId: vi.fn(),
 }));
 
+vi.mock("../../../utils/matchUtils", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../utils/matchUtils")>();
+  return {
+    ...actual,
+    preloadMedia: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
 vi.mock("./Team", () => ({
   default: ({
     teamName,
@@ -172,6 +181,7 @@ const defaultMatch = {
 function setupMocks(overrides?: {
   match?: Partial<typeof defaultMatch>;
   roster?: Roster;
+  view?: Record<string, unknown>;
 }) {
   const mockClearRoster = vi.fn();
   const mockSetRoster = vi.fn();
@@ -208,7 +218,7 @@ function setupMocks(overrides?: {
   } as unknown as ReturnType<typeof useListeners>);
 
   mockedUseView.mockReturnValue({
-    view: {},
+    view: overrides?.view ?? {},
     setGoalGifSettings: vi.fn(),
   } as unknown as ReturnType<typeof useView>);
 
@@ -731,6 +741,78 @@ describe("TeamAssetController", () => {
         expect(mockShowItemNow).toHaveBeenCalledWith({
           ...playerAsset,
           isGoalCelebration: true,
+        });
+      });
+    });
+
+    it("selects goal scorer with goalGif2 background", async () => {
+      const { mockShowItemNow } = setupMocks({
+        roster: mockRoster,
+        view: { goalGif1: "gif1.gif", goalGif2: "gif2.mp4" },
+      });
+
+      const playerAsset = {
+        type: "PLAYER",
+        key: "player-key",
+        name: "Jón",
+        number: 10,
+      };
+      mockedGetPlayerAssetObject.mockResolvedValue(
+        playerAsset as unknown as Awaited<
+          ReturnType<typeof getPlayerAssetObject>
+        >,
+      );
+
+      render(<TeamAssetController previousView={mockPreviousView} />);
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Birta markaskorara" }),
+      );
+      fireEvent.click(screen.getByTestId("select-player-homeTeam"));
+
+      await waitFor(() => {
+        expect(mockShowItemNow).toHaveBeenCalledWith({
+          ...playerAsset,
+          isGoalCelebration: true,
+          background: "gif2.mp4",
+        });
+      });
+    });
+
+    it("uses goalGif1 as background when goalGifSameImage is true", async () => {
+      const { mockShowItemNow } = setupMocks({
+        roster: mockRoster,
+        view: {
+          goalGif1: "gif1.gif",
+          goalGif2: "gif2.mp4",
+          goalGifSameImage: true,
+        },
+      });
+
+      const playerAsset = {
+        type: "PLAYER",
+        key: "player-key",
+        name: "Jón",
+        number: 10,
+      };
+      mockedGetPlayerAssetObject.mockResolvedValue(
+        playerAsset as unknown as Awaited<
+          ReturnType<typeof getPlayerAssetObject>
+        >,
+      );
+
+      render(<TeamAssetController previousView={mockPreviousView} />);
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Birta markaskorara" }),
+      );
+      fireEvent.click(screen.getByTestId("select-player-homeTeam"));
+
+      await waitFor(() => {
+        expect(mockShowItemNow).toHaveBeenCalledWith({
+          ...playerAsset,
+          isGoalCelebration: true,
+          background: "gif1.gif",
         });
       });
     });

--- a/clock/src/controller/asset/team/TeamAssetController.tsx
+++ b/clock/src/controller/asset/team/TeamAssetController.tsx
@@ -17,7 +17,7 @@ import { useRemoteSettings } from "../../../contexts/LocalStateContext";
 import "../../../api/clientConfig";
 import { getLineups } from "../../../api/client";
 import { transformLineups, getTeamId } from "../../../lib/matchUtils";
-import { resolveGoalBackground, preloadMedia } from "../../../utils/matchUtils";
+import { resolveGoalBackground } from "../../../utils/matchUtils";
 
 interface SubPlayer extends Player {
   teamName: string;
@@ -194,16 +194,13 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
     const actualTeamName =
       teamName === "homeTeam" ? match.homeTeam : match.awayTeam;
     void (async () => {
-      const goalBg = resolveGoalBackground(view);
-      const [goalAsset] = await Promise.all([
-        getPlayerAssetObject({
-          player,
-          teamName: actualTeamName,
-          listenPrefix,
-        }),
-        goalBg ? preloadMedia(goalBg) : Promise.resolve(),
-      ]);
+      const goalAsset = await getPlayerAssetObject({
+        player,
+        teamName: actualTeamName,
+        listenPrefix,
+      });
       if (!goalAsset) return;
+      const goalBg = resolveGoalBackground(view);
       showItemNow({
         ...goalAsset,
         isGoalCelebration: true,

--- a/clock/src/controller/asset/team/TeamAssetController.tsx
+++ b/clock/src/controller/asset/team/TeamAssetController.tsx
@@ -17,6 +17,7 @@ import { useRemoteSettings } from "../../../contexts/LocalStateContext";
 import "../../../api/clientConfig";
 import { getLineups } from "../../../api/client";
 import { transformLineups, getTeamId } from "../../../lib/matchUtils";
+import { resolveGoalBackground, preloadMedia } from "../../../utils/matchUtils";
 
 interface SubPlayer extends Player {
   teamName: string;
@@ -193,13 +194,21 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
     const actualTeamName =
       teamName === "homeTeam" ? match.homeTeam : match.awayTeam;
     void (async () => {
-      const goalAsset = await getPlayerAssetObject({
-        player,
-        teamName: actualTeamName,
-        listenPrefix,
-      });
+      const goalBg = resolveGoalBackground(view);
+      const [goalAsset] = await Promise.all([
+        getPlayerAssetObject({
+          player,
+          teamName: actualTeamName,
+          listenPrefix,
+        }),
+        goalBg ? preloadMedia(goalBg) : Promise.resolve(),
+      ]);
       if (!goalAsset) return;
-      showItemNow({ ...goalAsset, isGoalCelebration: true });
+      showItemNow({
+        ...goalAsset,
+        isGoalCelebration: true,
+        ...(goalBg ? { background: goalBg } : {}),
+      });
       clearState();
     })();
   };

--- a/clock/src/utils/matchUtils.spec.ts
+++ b/clock/src/utils/matchUtils.spec.ts
@@ -7,6 +7,7 @@ import {
   isMatchResetDisabled,
   teamToStateKey,
   translateTeam,
+  resolveGoalBackground,
 } from "./matchUtils";
 import { DEFAULT_HALFSTOPS, Sports } from "../constants";
 import { Match } from "../types";
@@ -162,6 +163,57 @@ describe("matchUtils", () => {
 
     it("translates away to Úti", () => {
       expect(translateTeam("away")).toBe("Úti");
+    });
+  });
+
+  describe("resolveGoalBackground", () => {
+    it("returns goalGif2 when set and sameImage is false", () => {
+      expect(
+        resolveGoalBackground({
+          goalGif1: "gif1.gif",
+          goalGif2: "gif2.mp4",
+          goalGifSameImage: false,
+        }),
+      ).toBe("gif2.mp4");
+    });
+
+    it("returns goalGif1 when goalGifSameImage is true", () => {
+      expect(
+        resolveGoalBackground({
+          goalGif1: "gif1.gif",
+          goalGif2: "gif2.mp4",
+          goalGifSameImage: true,
+        }),
+      ).toBe("gif1.gif");
+    });
+
+    it("returns goalGif1 when goalGif2 is missing", () => {
+      expect(
+        resolveGoalBackground({
+          goalGif1: "gif1.gif",
+          goalGifSameImage: false,
+        }),
+      ).toBe("gif1.gif");
+    });
+
+    it("returns goalGif1 when goalGif2 is null", () => {
+      expect(
+        resolveGoalBackground({
+          goalGif1: "gif1.gif",
+          goalGif2: null,
+          goalGifSameImage: false,
+        }),
+      ).toBe("gif1.gif");
+    });
+
+    it("returns undefined when no goal gifs are set", () => {
+      expect(resolveGoalBackground({})).toBeUndefined();
+    });
+
+    it("returns undefined when goalGif1 is null and sameImage is true", () => {
+      expect(
+        resolveGoalBackground({ goalGif1: null, goalGifSameImage: true }),
+      ).toBeUndefined();
     });
   });
 });

--- a/clock/src/utils/matchUtils.ts
+++ b/clock/src/utils/matchUtils.ts
@@ -60,6 +60,35 @@ export function isVideoUrl(url: string): boolean {
   return /\.(mp4|webm|mov|avi)/.test(lower);
 }
 
+export function resolveGoalBackground(view: {
+  goalGif1?: string | null;
+  goalGif2?: string | null;
+  goalGifSameImage?: boolean;
+}): string | undefined {
+  if (view.goalGifSameImage || !view.goalGif2) {
+    return view.goalGif1 ?? undefined;
+  }
+  return view.goalGif2;
+}
+
+export function preloadMedia(url: string): Promise<void> {
+  if (isVideoUrl(url)) {
+    return new Promise((resolve) => {
+      const video = document.createElement("video");
+      video.preload = "auto";
+      video.oncanplaythrough = () => resolve();
+      video.onerror = () => resolve();
+      video.src = url;
+    });
+  }
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => resolve();
+    img.onerror = () => resolve();
+    img.src = url;
+  });
+}
+
 /**
  * Normalizes a time string to 24h HH:mm format.
  * Handles AM/PM formats (e.g. "7:15 PM" → "19:15") and


### PR DESCRIPTION
## Summary

- **Birta markaskorara** in TeamAssetController now shows the goal cycle background (goalGif2) behind the player card, matching the automatic goal scoring flow via GoalScorerDialog
- Respects the "Nota sömu mynd" edge case: uses goalGif1 when enabled or when goalGif2 is not set
- Extracts `resolveGoalBackground()` and `preloadMedia()` into shared `matchUtils.ts` to eliminate duplication across TeamAssetController, GoalScorerDialog, and App.tsx

## Changes

- `matchUtils.ts`: Add `resolveGoalBackground()` (goal background resolution) and `preloadMedia()` (image/video preloader)
- `TeamAssetController.tsx`: Use shared helpers in `selectGoalScorerAction` to resolve, preload, and apply goal background
- `GoalScorerDialog.tsx`: Remove local `preloadMedia` duplicate, import from shared utils
- `App.tsx`: Replace inline goal background logic with `resolveGoalBackground()`
- Tests: 6 unit tests for `resolveGoalBackground`, 2 integration tests for goal scorer background in TeamAssetController

Closes #179