### PR TITLE
feat: Full-screen player selection modal for goals and substitutions

### DIFF
--- a/clock/src/controller/GoalScorerDialog.tsx
+++ b/clock/src/controller/GoalScorerDialog.tsx
@@ -1,10 +1,10 @@
-import { useState, useEffect, useRef, useCallback } from "react";
-import { Modal } from "rsuite";
+import { useCallback } from "react";
 import { Player } from "../types";
 import { getPlayerAssetObject } from "./asset/team/assetHelpers";
 import { useController } from "../contexts/FirebaseStateContext";
 import { useRemoteSettings } from "../contexts/LocalStateContext";
 import { preloadMedia } from "../utils/matchUtils";
+import TeamPlayerSelectionModal from "./asset/team/TeamPlayerSelectionModal";
 
 interface GoalScorerDialogProps {
   open: boolean;
@@ -23,12 +23,6 @@ const GoalScorerDialog = ({
 }: GoalScorerDialogProps) => {
   const { renderAsset } = useController();
   const { listenPrefix } = useRemoteSettings();
-  const [numberInput, setNumberInput] = useState("");
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  const filtered = numberInput
-    ? players.filter((p) => String(p.number ?? "").startsWith(numberInput))
-    : players;
 
   const selectPlayer = useCallback(
     (player: Player) => {
@@ -54,100 +48,15 @@ const GoalScorerDialog = ({
     [teamName, listenPrefix, renderAsset, onClose, goalGif2],
   );
 
-  const handleEntered = useCallback(() => {
-    setNumberInput("");
-    inputRef.current?.focus();
-  }, []);
-
-  useEffect(() => {
-    if (!open) return;
-    if (filtered.length === 1 && numberInput.length > 0) {
-      const handleEnter = (e: KeyboardEvent) => {
-        if (e.key === "Enter" && filtered[0]) {
-          e.preventDefault();
-          selectPlayer(filtered[0]);
-        }
-      };
-      window.addEventListener("keydown", handleEnter);
-      return () => window.removeEventListener("keydown", handleEnter);
-    }
-  }, [open, filtered, numberInput, selectPlayer]);
-
-  const handleExited = useCallback(() => {
-    setNumberInput("");
-  }, []);
-
-  const formatPlayer = (p: Player): string => {
-    const num = p.number ?? "";
-    return `#${String(num)} ${p.name}`;
-  };
-
   return (
-    <Modal
+    <TeamPlayerSelectionModal
       open={open}
       onClose={onClose}
-      onEntered={handleEntered}
-      onExited={handleExited}
-      size="xs"
-    >
-      <Modal.Header>
-        <Modal.Title>Markaskorari &mdash; {teamName}</Modal.Title>
-      </Modal.Header>
-      <Modal.Body>
-        <input
-          ref={inputRef}
-          type="text"
-          inputMode="numeric"
-          value={numberInput}
-          onChange={(e) => setNumberInput(e.target.value)}
-          placeholder="Sláðu inn númer leikmanns..."
-          style={{
-            width: "100%",
-            padding: "8px 10px",
-            fontSize: 18,
-            boxSizing: "border-box",
-            marginBottom: 10,
-          }}
-          autoFocus
-        />
-        <div
-          style={{
-            maxHeight: 350,
-            overflowY: "auto",
-            display: "flex",
-            flexDirection: "column",
-            gap: 2,
-          }}
-        >
-          {filtered.length === 0 && (
-            <div style={{ padding: 8, opacity: 0.5 }}>
-              Enginn leikmaður með númer &quot;{numberInput}&quot;
-            </div>
-          )}
-          {filtered.map((p) => (
-            <button
-              key={`${String(p.number)}-${p.name}`}
-              type="button"
-              onClick={() => selectPlayer(p)}
-              style={{
-                display: "block",
-                width: "100%",
-                textAlign: "left",
-                padding: "6px 10px",
-                fontSize: 15,
-                border: "1px solid #3c3f43",
-                borderRadius: 4,
-                background: filtered.length === 1 ? "#1675e0" : "transparent",
-                color: filtered.length === 1 ? "white" : "inherit",
-                cursor: "pointer",
-              }}
-            >
-              {formatPlayer(p)}
-            </button>
-          ))}
-        </div>
-      </Modal.Body>
-    </Modal>
+      title={`Markaskorari — ${teamName}`}
+      instruction="Veldu leikmann sem skoraði"
+      players={players}
+      onSelect={selectPlayer}
+    />
   );
 };
 

--- a/clock/src/controller/asset/team/TeamAssetController.spec.tsx
+++ b/clock/src/controller/asset/team/TeamAssetController.spec.tsx
@@ -90,6 +90,45 @@ vi.mock("./SubView", () => ({
   ),
 }));
 
+vi.mock("./TeamPlayerSelectionModal", () => ({
+  default: ({
+    open,
+    onClose,
+    title,
+    instruction,
+    players,
+    onSelect,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    title: string;
+    instruction?: string;
+    players: Player[];
+    onSelect: (player: Player) => void;
+  }) =>
+    open ? (
+      <div data-testid="player-select-modal">
+        <div data-testid="player-select-title">{title}</div>
+        {instruction ? (
+          <div data-testid="player-select-instruction">{instruction}</div>
+        ) : null}
+        <button type="button" onClick={onClose}>
+          Close modal
+        </button>
+        {players.map((player) => (
+          <button
+            key={`${String(player.number)}-${player.name}`}
+            type="button"
+            data-testid={`modal-player-${player.name}`}
+            onClick={() => onSelect(player)}
+          >
+            {player.name}
+          </button>
+        ))}
+      </div>
+    ) : null,
+}));
+
 vi.mock("./assetHelpers", () => ({
   getPlayerAssetObject: vi.fn(),
   getMOTMAsset: vi.fn(),
@@ -123,6 +162,13 @@ const mockPlayers: Player[] = [
     role: "keeper",
     show: true,
   },
+  {
+    name: "Siggi Bekkur",
+    id: 104,
+    number: 12,
+    role: "midfielder",
+    show: false,
+  },
 ];
 
 const mockAwayPlayers: Player[] = [
@@ -139,6 +185,13 @@ const mockAwayPlayers: Player[] = [
     number: 5,
     role: "defender",
     show: true,
+  },
+  {
+    name: "Arnar Bekkur",
+    id: 203,
+    number: 14,
+    role: "defender",
+    show: false,
   },
 ];
 
@@ -177,6 +230,7 @@ function setupMocks(overrides?: {
   const mockClearRoster = vi.fn();
   const mockSetRoster = vi.fn();
   const mockShowItemNow = vi.fn();
+  const mockEditPlayer = vi.fn();
   const mockCreateQueue = vi
     .fn<(name: string) => string>()
     .mockReturnValue("new-queue-id");
@@ -195,6 +249,7 @@ function setupMocks(overrides?: {
     clearRoster: mockClearRoster,
     setRoster: mockSetRoster,
     showItemNow: mockShowItemNow,
+    editPlayer: mockEditPlayer,
     createQueue: mockCreateQueue,
     deleteQueue: mockDeleteQueue,
     addItemsToQueue: mockAddItemsToQueue,
@@ -219,6 +274,7 @@ function setupMocks(overrides?: {
     mockClearRoster,
     mockSetRoster,
     mockShowItemNow,
+    mockEditPlayer,
     mockCreateQueue,
     mockDeleteQueue,
     mockAddItemsToQueue,
@@ -458,9 +514,9 @@ describe("TeamAssetController", () => {
 
       render(<TeamAssetController previousView={mockPreviousView} />);
 
-      expect(
-        screen.getByRole("button", { name: "Skipting" }),
-      ).toBeInTheDocument();
+      expect(screen.getAllByRole("button", { name: "Skipting" })).toHaveLength(
+        2,
+      );
       expect(
         screen.getByRole("button", { name: "Birta leikmann" }),
       ).toBeInTheDocument();
@@ -474,59 +530,68 @@ describe("TeamAssetController", () => {
   });
 
   describe("substitution flow", () => {
-    it("enters sub mode and shows cancel button", () => {
+    it("opens sub modal and shows starter instruction", () => {
       setupMocks({ roster: mockRoster });
 
       render(<TeamAssetController previousView={mockPreviousView} />);
 
-      fireEvent.click(screen.getByRole("button", { name: "Skipting" }));
+      const subButtons = screen.getAllByRole("button", { name: "Skipting" });
+      fireEvent.click(subButtons[0]);
 
-      expect(
-        screen.getByRole("button", { name: "Hætta við skiptingu" }),
-      ).toBeInTheDocument();
-      expect(screen.getByTestId("sub-view")).toBeInTheDocument();
-    });
-
-    it("cancels sub mode when cancel button clicked", () => {
-      setupMocks({ roster: mockRoster });
-
-      render(<TeamAssetController previousView={mockPreviousView} />);
-
-      fireEvent.click(screen.getByRole("button", { name: "Skipting" }));
-      fireEvent.click(
-        screen.getByRole("button", { name: "Hætta við skiptingu" }),
+      expect(screen.getByTestId("player-select-modal")).toBeInTheDocument();
+      expect(screen.getByTestId("player-select-instruction")).toHaveTextContent(
+        "Veldu leikmann sem fer AF velli",
       );
+    });
+
+    it("closes sub modal when close button clicked", () => {
+      setupMocks({ roster: mockRoster });
+
+      render(<TeamAssetController previousView={mockPreviousView} />);
+
+      const subButtons = screen.getAllByRole("button", { name: "Skipting" });
+      fireEvent.click(subButtons[0]);
+      fireEvent.click(screen.getByRole("button", { name: "Close modal" }));
 
       expect(
-        screen.getByRole("button", { name: "Skipting" }),
+        screen.queryByTestId("player-select-modal"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows sub modal players for the selected team", () => {
+      setupMocks({ roster: mockRoster });
+
+      render(<TeamAssetController previousView={mockPreviousView} />);
+
+      const subButtons = screen.getAllByRole("button", { name: "Skipting" });
+      fireEvent.click(subButtons[0]);
+
+      expect(
+        screen.getByTestId("modal-player-Jón Jónsson"),
       ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("modal-player-Gunnar Gunnarsson"),
+      ).not.toBeInTheDocument();
     });
 
-    it("enables player selection on Team components during sub mode", () => {
+    it("selects sub off player and advances modal instruction", () => {
       setupMocks({ roster: mockRoster });
 
       render(<TeamAssetController previousView={mockPreviousView} />);
 
-      fireEvent.click(screen.getByRole("button", { name: "Skipting" }));
+      const subButtons = screen.getAllByRole("button", { name: "Skipting" });
+      fireEvent.click(subButtons[0]);
+      fireEvent.click(screen.getByTestId("modal-player-Jón Jónsson"));
 
-      expect(screen.getByTestId("select-player-homeTeam")).toBeInTheDocument();
-      expect(screen.getByTestId("select-player-awayTeam")).toBeInTheDocument();
-    });
-
-    it("selects first sub player (subIn) and shows SubView", () => {
-      setupMocks({ roster: mockRoster });
-
-      render(<TeamAssetController previousView={mockPreviousView} />);
-
-      fireEvent.click(screen.getByRole("button", { name: "Skipting" }));
-      fireEvent.click(screen.getByTestId("select-player-homeTeam"));
-
-      expect(screen.getByTestId("sub-in")).toBeInTheDocument();
-      expect(screen.getByTestId("sub-team")).toHaveTextContent("Víkingur R");
+      expect(screen.getByTestId("player-select-instruction")).toHaveTextContent(
+        "veldu leikmann sem kemur INN",
+      );
     });
 
     it("completes substitution flow when both players selected", async () => {
-      const { mockShowItemNow } = setupMocks({ roster: mockRoster });
+      const { mockShowItemNow, mockEditPlayer } = setupMocks({
+        roster: mockRoster,
+      });
 
       const subInAsset = {
         type: "PLAYER",
@@ -554,13 +619,16 @@ describe("TeamAssetController", () => {
 
       render(<TeamAssetController previousView={mockPreviousView} />);
 
-      fireEvent.click(screen.getByRole("button", { name: "Skipting" }));
-      fireEvent.click(screen.getByTestId("select-player-homeTeam"));
-      fireEvent.click(screen.getByTestId("select-player-homeTeam"));
+      const subButtons = screen.getAllByRole("button", { name: "Skipting" });
+      fireEvent.click(subButtons[0]);
+      fireEvent.click(screen.getByTestId("modal-player-Jón Jónsson"));
+      fireEvent.click(screen.getByTestId("modal-player-Siggi Bekkur"));
 
       await waitFor(() => {
         expect(mockShowItemNow).toHaveBeenCalled();
       });
+
+      expect(mockEditPlayer).toHaveBeenCalled();
 
       const callArgs = mockShowItemNow.mock.calls[0]!;
       expect(callArgs[0]).toEqual(
@@ -579,9 +647,10 @@ describe("TeamAssetController", () => {
 
       render(<TeamAssetController previousView={mockPreviousView} />);
 
-      fireEvent.click(screen.getByRole("button", { name: "Skipting" }));
-      fireEvent.click(screen.getByTestId("select-player-homeTeam"));
-      fireEvent.click(screen.getByTestId("select-player-homeTeam"));
+      const subButtons = screen.getAllByRole("button", { name: "Skipting" });
+      fireEvent.click(subButtons[0]);
+      fireEvent.click(screen.getByTestId("modal-player-Jón Jónsson"));
+      fireEvent.click(screen.getByTestId("modal-player-Siggi Bekkur"));
 
       await waitFor(() => {
         expect(mockedGetPlayerAssetObject).toHaveBeenCalled();
@@ -686,7 +755,7 @@ describe("TeamAssetController", () => {
   });
 
   describe("select goal scorer", () => {
-    it("enters goal scorer mode and shows cancel button", () => {
+    it("opens goal scorer modal with instruction", () => {
       setupMocks({ roster: mockRoster });
 
       render(<TeamAssetController previousView={mockPreviousView} />);
@@ -695,9 +764,10 @@ describe("TeamAssetController", () => {
         screen.getByRole("button", { name: "Birta markaskorara" }),
       );
 
-      expect(
-        screen.getByRole("button", { name: "Hætta við birtingu" }),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("player-select-modal")).toBeInTheDocument();
+      expect(screen.getByTestId("player-select-instruction")).toHaveTextContent(
+        "Veldu leikmann sem skoraði",
+      );
     });
 
     it("selects goal scorer with isGoalCelebration flag", async () => {
@@ -720,7 +790,7 @@ describe("TeamAssetController", () => {
       fireEvent.click(
         screen.getByRole("button", { name: "Birta markaskorara" }),
       );
-      fireEvent.click(screen.getByTestId("select-player-homeTeam"));
+      fireEvent.click(screen.getByTestId("modal-player-Jón Jónsson"));
 
       expect(mockedGetPlayerAssetObject).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -759,7 +829,7 @@ describe("TeamAssetController", () => {
       fireEvent.click(
         screen.getByRole("button", { name: "Birta markaskorara" }),
       );
-      fireEvent.click(screen.getByTestId("select-player-homeTeam"));
+      fireEvent.click(screen.getByTestId("modal-player-Jón Jónsson"));
 
       await waitFor(() => {
         expect(mockShowItemNow).toHaveBeenCalledWith({
@@ -797,7 +867,7 @@ describe("TeamAssetController", () => {
       fireEvent.click(
         screen.getByRole("button", { name: "Birta markaskorara" }),
       );
-      fireEvent.click(screen.getByTestId("select-player-homeTeam"));
+      fireEvent.click(screen.getByTestId("modal-player-Jón Jónsson"));
 
       await waitFor(() => {
         expect(mockShowItemNow).toHaveBeenCalledWith({
@@ -915,7 +985,7 @@ describe("TeamAssetController", () => {
       expect(screen.getByTestId("select-player-awayTeam")).toBeInTheDocument();
     });
 
-    it("passes selectPlayer to both teams in goal scorer mode", () => {
+    it("does not pass selectPlayer to Team in goal scorer mode", () => {
       setupMocks({ roster: mockRoster });
 
       render(<TeamAssetController previousView={mockPreviousView} />);
@@ -924,8 +994,12 @@ describe("TeamAssetController", () => {
         screen.getByRole("button", { name: "Birta markaskorara" }),
       );
 
-      expect(screen.getByTestId("select-player-homeTeam")).toBeInTheDocument();
-      expect(screen.getByTestId("select-player-awayTeam")).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("select-player-homeTeam"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("select-player-awayTeam"),
+      ).not.toBeInTheDocument();
     });
 
     it("passes selectPlayer to both teams in MOTM mode", () => {
@@ -943,7 +1017,7 @@ describe("TeamAssetController", () => {
   });
 
   describe("cancel display mode", () => {
-    it("cancels goal scorer mode from cancel button", () => {
+    it("closes goal scorer modal from close button", () => {
       setupMocks({ roster: mockRoster });
 
       render(<TeamAssetController previousView={mockPreviousView} />);
@@ -951,17 +1025,13 @@ describe("TeamAssetController", () => {
       fireEvent.click(
         screen.getByRole("button", { name: "Birta markaskorara" }),
       );
-      expect(
-        screen.getByRole("button", { name: "Hætta við birtingu" }),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("player-select-modal")).toBeInTheDocument();
 
-      fireEvent.click(
-        screen.getByRole("button", { name: "Hætta við birtingu" }),
-      );
+      fireEvent.click(screen.getByRole("button", { name: "Close modal" }));
 
       expect(
-        screen.getByRole("button", { name: "Skipting" }),
-      ).toBeInTheDocument();
+        screen.queryByTestId("player-select-modal"),
+      ).not.toBeInTheDocument();
     });
 
     it("cancels MOTM mode from cancel button", () => {
@@ -976,36 +1046,37 @@ describe("TeamAssetController", () => {
         screen.getByRole("button", { name: "Hætta við birtingu" }),
       );
 
-      expect(
-        screen.getByRole("button", { name: "Skipting" }),
-      ).toBeInTheDocument();
+      expect(screen.getAllByRole("button", { name: "Skipting" })).toHaveLength(
+        2,
+      );
     });
   });
 
-  describe("SubView during substitution", () => {
-    it("shows correct team name in SubView for home team sub", () => {
+  describe("substitution modal content", () => {
+    it("shows home team name in modal title for home sub", () => {
       setupMocks({ roster: mockRoster });
 
       render(<TeamAssetController previousView={mockPreviousView} />);
 
-      fireEvent.click(screen.getByRole("button", { name: "Skipting" }));
+      const subButtons = screen.getAllByRole("button", { name: "Skipting" });
+      fireEvent.click(subButtons[0]);
 
-      expect(screen.queryByTestId("sub-team")).not.toBeInTheDocument();
-
-      fireEvent.click(screen.getByTestId("select-player-homeTeam"));
-
-      expect(screen.getByTestId("sub-team")).toHaveTextContent("Víkingur R");
+      expect(screen.getByTestId("player-select-title")).toHaveTextContent(
+        "Skipting – Víkingur R",
+      );
     });
 
-    it("shows correct team name in SubView for away team sub", () => {
+    it("shows away team name in modal title for away sub", () => {
       setupMocks({ roster: mockRoster });
 
       render(<TeamAssetController previousView={mockPreviousView} />);
 
-      fireEvent.click(screen.getByRole("button", { name: "Skipting" }));
-      fireEvent.click(screen.getByTestId("select-player-awayTeam"));
+      const subButtons = screen.getAllByRole("button", { name: "Skipting" });
+      fireEvent.click(subButtons[1]);
 
-      expect(screen.getByTestId("sub-team")).toHaveTextContent("KR");
+      expect(screen.getByTestId("player-select-title")).toHaveTextContent(
+        "Skipting – KR",
+      );
     });
   });
 
@@ -1040,8 +1111,8 @@ describe("TeamAssetController", () => {
 
       await waitFor(() => {
         expect(
-          screen.getByRole("button", { name: "Skipting" }),
-        ).toBeInTheDocument();
+          screen.getAllByRole("button", { name: "Skipting" }),
+        ).toHaveLength(2);
       });
     });
 
@@ -1057,12 +1128,12 @@ describe("TeamAssetController", () => {
       fireEvent.click(
         screen.getByRole("button", { name: "Birta markaskorara" }),
       );
-      fireEvent.click(screen.getByTestId("select-player-homeTeam"));
+      fireEvent.click(screen.getByTestId("modal-player-Jón Jónsson"));
 
       await waitFor(() => {
         expect(
-          screen.getByRole("button", { name: "Skipting" }),
-        ).toBeInTheDocument();
+          screen.getAllByRole("button", { name: "Skipting" }),
+        ).toHaveLength(2);
       });
     });
 
@@ -1082,8 +1153,8 @@ describe("TeamAssetController", () => {
 
       await waitFor(() => {
         expect(
-          screen.getByRole("button", { name: "Skipting" }),
-        ).toBeInTheDocument();
+          screen.getAllByRole("button", { name: "Skipting" }),
+        ).toHaveLength(2);
       });
     });
   });

--- a/clock/src/controller/asset/team/TeamAssetController.tsx
+++ b/clock/src/controller/asset/team/TeamAssetController.tsx
@@ -263,12 +263,12 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
 
     void (async () => {
       const subInObj = await getPlayerAssetObject({
-        player: subOnTrimmed,
+        player: subOffTrimmed,
         teamName: actualTeamName,
         listenPrefix,
       });
       const subOutObj = await getPlayerAssetObject({
-        player: subOffTrimmed,
+        player: subOnTrimmed,
         teamName: actualTeamName,
         listenPrefix,
       });

--- a/clock/src/controller/asset/team/TeamAssetController.tsx
+++ b/clock/src/controller/asset/team/TeamAssetController.tsx
@@ -490,7 +490,9 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
       return (roster[modalTeamSide] || []).filter((p) => p.show);
     }
     if (modalMode === "subOn") {
-      return (roster[modalTeamSide] || []).filter((p) => !p.show);
+      return (roster[modalTeamSide] || []).filter(
+        (p) => !p.show && p.number != null,
+      );
     }
     return [];
   };

--- a/clock/src/controller/asset/team/TeamAssetController.tsx
+++ b/clock/src/controller/asset/team/TeamAssetController.tsx
@@ -4,6 +4,7 @@ import { RingLoader } from "react-spinners";
 
 import Team from "./Team";
 import SubView from "./SubView";
+import TeamPlayerSelectionModal from "./TeamPlayerSelectionModal";
 import assetTypes from "../AssetTypes";
 import { getMOTMAsset, getPlayerAssetObject } from "./assetHelpers";
 import { Asset, Player } from "../../../types";
@@ -23,6 +24,8 @@ interface SubPlayer extends Player {
   teamName: string;
 }
 
+type ModalMode = null | "goalScorer" | "subOff" | "subOn";
+
 interface OwnProps {
   previousView: () => void;
 }
@@ -34,6 +37,7 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
     controller,
     setRoster,
     clearRoster,
+    editPlayer,
     createQueue,
     deleteQueue,
     addItemsToQueue,
@@ -51,8 +55,11 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
   const [subIn, setSubIn] = useState<SubPlayer | null>(null);
   const [subOut, setSubOut] = useState<Player | null>(null);
   const [selectPlayerAsset, setSelectPlayerAsset] = useState(false);
-  const [selectGoalScorer, setSelectGoalScorer] = useState(false);
   const [selectMOTM, setSelectMOTM] = useState(false);
+
+  const [modalMode, setModalMode] = useState<ModalMode>(null);
+  const [modalTeamSide, setModalTeamSide] = useState<"home" | "away">("home");
+  const [subOffPlayer, setSubOffPlayer] = useState<Player | null>(null);
 
   const refetchRoster = (): void => {
     if (!match.ksiMatchId) return;
@@ -81,8 +88,9 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
     setSubIn(null);
     setSubOut(null);
     setSelectPlayerAsset(false);
-    setSelectGoalScorer(false);
     setSelectMOTM(false);
+    setModalMode(null);
+    setSubOffPlayer(null);
   };
 
   const addTeamToQueue = async (side: "home" | "away"): Promise<void> => {
@@ -190,9 +198,9 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
     })();
   };
 
-  const selectGoalScorerAction = (player: Player, teamName: string): void => {
-    const actualTeamName =
-      teamName === "homeTeam" ? match.homeTeam : match.awayTeam;
+  const handleGoalScorerModalSelect = (player: Player): void => {
+    const actualTeamName = match.homeTeam;
+    setModalMode(null);
     void (async () => {
       const goalAsset = await getPlayerAssetObject({
         player,
@@ -206,7 +214,81 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
         isGoalCelebration: true,
         ...(goalBg ? { background: goalBg } : {}),
       });
-      clearState();
+    })();
+  };
+
+  const openSubModal = (side: "home" | "away"): void => {
+    setModalTeamSide(side);
+    setSubOffPlayer(null);
+    setModalMode("subOff");
+  };
+
+  const handleSubOffSelect = (player: Player): void => {
+    setSubOffPlayer(player);
+    setModalMode("subOn");
+  };
+
+  const handleSubOnSelect = (player: Player): void => {
+    if (!subOffPlayer) return;
+    const side = modalTeamSide;
+    const teamKey = side === "home" ? "homeTeam" : "awayTeam";
+    const actualTeamName = side === "home" ? match.homeTeam : match.awayTeam;
+    const players = roster[side] || [];
+
+    const offIdx = players.findIndex(
+      (p) => p.number === subOffPlayer.number && p.name === subOffPlayer.name,
+    );
+    const onIdx = players.findIndex(
+      (p) => p.number === player.number && p.name === player.name,
+    );
+    if (offIdx !== -1) editPlayer(side, offIdx, { show: false });
+    if (onIdx !== -1) editPlayer(side, onIdx, { show: true });
+
+    setModalMode(null);
+
+    const subOffTrimmed: Player = {
+      ...subOffPlayer,
+      name: subOffPlayer.name
+        .split(" ")
+        .slice(0, subOffPlayer.name.split(" ").length - 1)
+        .join(" "),
+    };
+    const subOnTrimmed: Player = {
+      ...player,
+      name: player.name
+        .split(" ")
+        .slice(0, player.name.split(" ").length - 1)
+        .join(" "),
+    };
+
+    void (async () => {
+      const subInObj = await getPlayerAssetObject({
+        player: subOnTrimmed,
+        teamName: actualTeamName,
+        listenPrefix,
+      });
+      const subOutObj = await getPlayerAssetObject({
+        player: subOffTrimmed,
+        teamName: actualTeamName,
+        listenPrefix,
+      });
+      if (!subInObj || !subOutObj) return;
+      const homeRevealBg = view.homeTeamRevealBackground;
+      const isHome = teamKey === "homeTeam";
+      const finalSubIn =
+        isHome && homeRevealBg
+          ? { ...subInObj, background: homeRevealBg }
+          : subInObj;
+      const finalSubOut =
+        isHome && homeRevealBg
+          ? { ...subOutObj, background: homeRevealBg }
+          : subOutObj;
+      showItemNow({
+        type: assetTypes.SUB,
+        subIn: finalSubIn,
+        subOut: finalSubOut,
+        key: `sub-${subInObj.key}-${subOutObj.key}`,
+      });
     })();
   };
 
@@ -230,8 +312,7 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
     })();
   };
 
-  const isPlayerActionActive =
-    selectSubs || selectPlayerAsset || selectGoalScorer || selectMOTM;
+  const isPlayerActionActive = selectSubs || selectPlayerAsset || selectMOTM;
 
   const renderCancelButton = (): React.JSX.Element | null => {
     if (selectSubs) {
@@ -250,14 +331,13 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
         </button>
       );
     }
-    if (selectPlayerAsset || selectGoalScorer || selectMOTM) {
+    if (selectPlayerAsset || selectMOTM) {
       return (
         <button
           type="button"
           className="cancel-btn"
           onClick={() => {
             setSelectPlayerAsset(false);
-            setSelectGoalScorer(false);
             setSelectMOTM(false);
           }}
         >
@@ -292,13 +372,10 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
         ) : (
           <>
             <div className="button-row">
-              <button type="button" onClick={() => setSelectSubs(true)}>
-                Skipting
-              </button>
               <button type="button" onClick={() => setSelectPlayerAsset(true)}>
                 Birta leikmann
               </button>
-              <button type="button" onClick={() => setSelectGoalScorer(true)}>
+              <button type="button" onClick={() => setModalMode("goalScorer")}>
                 Birta markaskorara
               </button>
               <button type="button" onClick={() => setSelectMOTM(true)}>
@@ -354,25 +431,78 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
       }
     } else if (selectPlayerAsset) {
       selectPlayerAction = selectPlayerAssetAction;
-    } else if (selectGoalScorer) {
-      selectPlayerAction = selectGoalScorerAction;
     } else if (selectMOTM) {
       selectPlayerAction = selectMOTMAction;
     }
     return (
       <div className="team-column-wrapper">
         {hasPlayers && !isPlayerActionActive ? (
-          <button
-            type="button"
-            className="queue-team-btn"
-            onClick={() => void addTeamToQueue(side)}
-          >
-            Setja lið í biðröð
-          </button>
+          <>
+            <button
+              type="button"
+              className="queue-team-btn"
+              onClick={() => void addTeamToQueue(side)}
+            >
+              Setja lið í biðröð
+            </button>
+            <button
+              type="button"
+              className="queue-team-btn"
+              onClick={() => openSubModal(side)}
+            >
+              Skipting
+            </button>
+          </>
         ) : null}
         <Team teamName={teamName} selectPlayer={selectPlayerAction} />
       </div>
     );
+  };
+
+  const getModalTitle = (): string => {
+    if (modalMode === "goalScorer") return "Veldu markaskorara";
+    if (modalMode === "subOff") {
+      const teamName =
+        modalTeamSide === "home" ? match.homeTeam : match.awayTeam;
+      return `Skipting – ${teamName}`;
+    }
+    if (modalMode === "subOn") {
+      const teamName =
+        modalTeamSide === "home" ? match.homeTeam : match.awayTeam;
+      return `Skipting – ${teamName}`;
+    }
+    return "";
+  };
+
+  const getModalInstruction = (): string => {
+    if (modalMode === "goalScorer") return "Veldu leikmann sem skoraði";
+    if (modalMode === "subOff") return "Veldu leikmann sem fer AF velli";
+    if (modalMode === "subOn" && subOffPlayer) {
+      const num = subOffPlayer.number ?? "";
+      return `#${String(num)} ${subOffPlayer.name} fer af – veldu leikmann sem kemur INN`;
+    }
+    return "";
+  };
+
+  const getModalPlayers = (): Player[] => {
+    if (modalMode === "goalScorer") return roster.home;
+    if (modalMode === "subOff") {
+      return (roster[modalTeamSide] || []).filter((p) => p.show);
+    }
+    if (modalMode === "subOn") {
+      return (roster[modalTeamSide] || []).filter((p) => !p.show);
+    }
+    return [];
+  };
+
+  const handleModalSelect = (player: Player): void => {
+    if (modalMode === "goalScorer") {
+      handleGoalScorerModalSelect(player);
+    } else if (modalMode === "subOff") {
+      handleSubOffSelect(player);
+    } else if (modalMode === "subOn") {
+      handleSubOnSelect(player);
+    }
   };
 
   if (!match.homeTeam || !match.awayTeam) {
@@ -387,6 +517,17 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
         {renderTeam("homeTeam")}
         {renderTeam("awayTeam")}
       </div>
+      <TeamPlayerSelectionModal
+        open={modalMode !== null}
+        onClose={() => {
+          setModalMode(null);
+          setSubOffPlayer(null);
+        }}
+        title={getModalTitle()}
+        instruction={getModalInstruction()}
+        players={getModalPlayers()}
+        onSelect={handleModalSelect}
+      />
     </div>
   );
 };

--- a/clock/src/controller/asset/team/TeamPlayerSelectionModal.css
+++ b/clock/src/controller/asset/team/TeamPlayerSelectionModal.css
@@ -31,7 +31,7 @@
 
 .player-grid {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   gap: 10px;
 }
 

--- a/clock/src/controller/asset/team/TeamPlayerSelectionModal.css
+++ b/clock/src/controller/asset/team/TeamPlayerSelectionModal.css
@@ -31,7 +31,7 @@
 
 .player-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  grid-template-columns: repeat(5, 1fr);
   gap: 10px;
 }
 
@@ -49,7 +49,7 @@
   transition:
     background 0.15s,
     border-color 0.15s;
-  min-height: 90px;
+  min-height: 110px;
 }
 
 .player-grid-cell:hover {
@@ -63,14 +63,14 @@
 }
 
 .player-grid-number {
-  font-size: 40px;
+  font-size: 48px;
   font-weight: 700;
   line-height: 1;
   font-variant-numeric: tabular-nums;
 }
 
 .player-grid-name {
-  font-size: 12px;
+  font-size: 13px;
   margin-top: 6px;
   text-align: center;
   overflow: hidden;

--- a/clock/src/controller/asset/team/TeamPlayerSelectionModal.css
+++ b/clock/src/controller/asset/team/TeamPlayerSelectionModal.css
@@ -1,0 +1,81 @@
+.player-select-modal .rs-modal-dialog {
+  max-width: 100%;
+  width: 100%;
+  margin: 0;
+}
+
+.player-select-modal .rs-modal-content {
+  min-height: 100vh;
+  border-radius: 0;
+}
+
+.player-select-instruction {
+  font-size: 15px;
+  opacity: 0.7;
+  margin: 0 0 12px;
+}
+
+.player-select-section-label {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  opacity: 0.5;
+  margin-bottom: 8px;
+}
+
+.player-select-section-label.bench-label {
+  margin-top: 24px;
+  padding-top: 16px;
+  border-top: 1px solid #3c3f43;
+}
+
+.player-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  gap: 10px;
+}
+
+.player-grid-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid #3c3f43;
+  border-radius: 8px;
+  background: #1a1d24;
+  color: #fff;
+  cursor: pointer;
+  padding: 12px 4px;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
+  min-height: 90px;
+}
+
+.player-grid-cell:hover {
+  background: #2a2d34;
+  border-color: #3498ff;
+}
+
+.player-grid-cell:active {
+  background: #3498ff;
+  border-color: #3498ff;
+}
+
+.player-grid-number {
+  font-size: 40px;
+  font-weight: 700;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.player-grid-name {
+  font-size: 12px;
+  margin-top: 6px;
+  text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+  padding: 0 2px;
+}

--- a/clock/src/controller/asset/team/TeamPlayerSelectionModal.tsx
+++ b/clock/src/controller/asset/team/TeamPlayerSelectionModal.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { Modal } from "rsuite";
+
+import { Player } from "../../../types";
+
+import "./TeamPlayerSelectionModal.css";
+
+interface TeamPlayerSelectionModalProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  players: Player[];
+  onSelect: (player: Player) => void;
+  /** Optional instruction text shown below the title */
+  instruction?: string;
+}
+
+const TeamPlayerSelectionModal: React.FC<TeamPlayerSelectionModalProps> = ({
+  open,
+  onClose,
+  title,
+  players,
+  onSelect,
+  instruction,
+}) => {
+  const starters = players.filter((p) => p.show);
+  const bench = players.filter((p) => !p.show);
+
+  const renderPlayerButton = (player: Player): React.JSX.Element => (
+    <button
+      key={`${String(player.number)}-${player.name}`}
+      type="button"
+      className="player-grid-cell"
+      onClick={() => onSelect(player)}
+    >
+      <span className="player-grid-number">
+        {player.number ?? (player.role ? player.role[0] : "?")}
+      </span>
+      <span className="player-grid-name">{player.name}</span>
+    </button>
+  );
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      size="full"
+      className="player-select-modal"
+    >
+      <Modal.Header>
+        <Modal.Title>{title}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        {instruction && (
+          <p className="player-select-instruction">{instruction}</p>
+        )}
+        {starters.length > 0 && (
+          <>
+            <div className="player-select-section-label">Á velli</div>
+            <div className="player-grid">
+              {starters.map(renderPlayerButton)}
+            </div>
+          </>
+        )}
+        {bench.length > 0 && (
+          <>
+            <div className="player-select-section-label bench-label">
+              Varamenn
+            </div>
+            <div className="player-grid">{bench.map(renderPlayerButton)}</div>
+          </>
+        )}
+      </Modal.Body>
+    </Modal>
+  );
+};
+
+export default TeamPlayerSelectionModal;

--- a/clock/src/controller/asset/team/TeamPlayerSelectionModal.tsx
+++ b/clock/src/controller/asset/team/TeamPlayerSelectionModal.tsx
@@ -23,8 +23,10 @@ const TeamPlayerSelectionModal: React.FC<TeamPlayerSelectionModalProps> = ({
   onSelect,
   instruction,
 }) => {
-  const starters = players.filter((p) => p.show);
-  const bench = players.filter((p) => !p.show);
+  const byNumber = (a: Player, b: Player): number =>
+    (Number(a.number) || Infinity) - (Number(b.number) || Infinity);
+  const starters = players.filter((p) => p.show).sort(byNumber);
+  const bench = players.filter((p) => !p.show).sort(byNumber);
 
   const renderPlayerButton = (player: Player): React.JSX.Element => (
     <button


### PR DESCRIPTION
## Summary

Closes #180

- **Goal scorer modal**: Full-screen overlay with large player number grid (home team only, 4 per row). Starters shown first, then bench section below.
- **Substitution modal**: Two-phase flow — first select the player going OFF (starters), then the player coming ON (bench, numbered players only — coaches/staff filtered out). Auto-toggles roster `show` flag (outgoing → hidden, incoming → visible).
- **Per-team Skipting button**: Each team now has its own "Skipting" button below "Setja lið í biðröð", replacing the shared button in player actions.

## Screenshots

### Goal scorer modal
![Goal scorer modal](https://staging-klukka.irdn.is/pr-images/180-goalscorer-modal-1778285092.png)

### Substitution — select player OFF
![Sub OFF modal](https://staging-klukka.irdn.is/pr-images/180-sub-off-modal-1778285092.png)

### Substitution — select player ON
![Sub ON modal](https://staging-klukka.irdn.is/pr-images/180-sub-on-modal-1778285092.png)

### Controller view with per-team Skipting buttons
![Controller view](https://staging-klukka.irdn.is/pr-images/180-controller-view-1778283709.png)

## Changes

- **New**: `TeamPlayerSelectionModal.tsx` + `.css` — reusable full-screen modal with 4-column number grid layout
- **Modified**: `TeamAssetController.tsx` — modal integration, per-team Skipting, auto show-flag toggle on substitution, coaches/staff filtered from sub ON list
- **Updated**: `TeamAssetController.spec.tsx` — tests updated for modal-based substitution and goal scorer flows

## Testing

- All unit tests pass (updated for modal-based flows)
- Playwright E2E verified: goal scorer modal, sub OFF→ON flow, show flag toggle, SUB asset creation
- ESLint: 0 new errors
- TypeScript: 0 new errors