### PR TITLE
Fix MOTM showing previous goal scorer due to stale keydown listener

### DIFF
--- a/clock/src/controller/GoalScorerDialog.tsx
+++ b/clock/src/controller/GoalScorerDialog.tsx
@@ -60,6 +60,7 @@ const GoalScorerDialog = ({
   }, []);
 
   useEffect(() => {
+    if (!open) return;
     if (filtered.length === 1 && numberInput.length > 0) {
       const handleEnter = (e: KeyboardEvent) => {
         if (e.key === "Enter" && filtered[0]) {
@@ -70,7 +71,11 @@ const GoalScorerDialog = ({
       window.addEventListener("keydown", handleEnter);
       return () => window.removeEventListener("keydown", handleEnter);
     }
-  }, [filtered, numberInput, selectPlayer]);
+  }, [open, filtered, numberInput, selectPlayer]);
+
+  const handleExited = useCallback(() => {
+    setNumberInput("");
+  }, []);
 
   const formatPlayer = (p: Player): string => {
     const num = p.number ?? "";
@@ -78,7 +83,13 @@ const GoalScorerDialog = ({
   };
 
   return (
-    <Modal open={open} onClose={onClose} onEntered={handleEntered} size="xs">
+    <Modal
+      open={open}
+      onClose={onClose}
+      onEntered={handleEntered}
+      onExited={handleExited}
+      size="xs"
+    >
       <Modal.Header>
         <Modal.Title>Markaskorari &mdash; {teamName}</Modal.Title>
       </Modal.Header>


### PR DESCRIPTION
## Summary

- Fix bug where selecting MOTM (man of the match) via number input + Enter would show the previous goal scorer with a goal background instead of the correct MOTM player
- `GoalScorerDialog` registered a global `window.keydown` listener for Enter that persisted after the dialog closed, intercepting Enter presses in the MOTM number input (`Team.tsx`)

## Changes

- Guard the keydown `useEffect` in `GoalScorerDialog.tsx` with the `open` prop so the listener is never registered when the dialog is hidden
- Reset `numberInput` state via `onExited` Modal callback to prevent stale player filter matches on next open

Fixes #182