### PR TITLE
feat: Queue substitutions into Skiptingar queue (#181)

### DIFF
--- a/clock/src/contexts/FirebaseStateContext.tsx
+++ b/clock/src/contexts/FirebaseStateContext.tsx
@@ -168,6 +168,7 @@ interface FirebaseStateContextType {
     settings: Partial<Pick<QueueState, "autoPlay" | "imageSeconds" | "cycle">>,
   ) => void;
   playQueue: (queueId: string) => void;
+  activateQueue: (queueId: string) => void;
   stopPlaying: () => void;
   showItemNow: (asset: Asset) => void;
   setPlaying: (playing: boolean) => void;
@@ -1091,6 +1092,16 @@ export const FirebaseStateProvider: React.FC<FirebaseStateProviderProps> = ({
     [applyControllerUpdate],
   );
 
+  const activateQueue = useCallback(
+    (queueId: string) => {
+      applyControllerUpdate((prev) => ({
+        ...prev,
+        activeQueueId: queueId,
+      }));
+    },
+    [applyControllerUpdate],
+  );
+
   const stopPlaying = useCallback(() => {
     applyControllerUpdate((prev) => ({ ...prev, playing: false }));
   }, [applyControllerUpdate]);
@@ -1417,6 +1428,7 @@ export const FirebaseStateProvider: React.FC<FirebaseStateProviderProps> = ({
       reorderItemsInQueue,
       updateQueueSettings,
       playQueue,
+      activateQueue,
       stopPlaying,
       showItemNow,
       setPlaying,
@@ -1479,6 +1491,7 @@ export const FirebaseStateProvider: React.FC<FirebaseStateProviderProps> = ({
       reorderItemsInQueue,
       updateQueueSettings,
       playQueue,
+      activateQueue,
       stopPlaying,
       showItemNow,
       setPlaying,
@@ -1580,6 +1593,7 @@ export const useController = () => {
     reorderItemsInQueue,
     updateQueueSettings,
     playQueue,
+    activateQueue,
     stopPlaying,
     showItemNow,
     setPlaying,
@@ -1608,6 +1622,7 @@ export const useController = () => {
     reorderItemsInQueue,
     updateQueueSettings,
     playQueue,
+    activateQueue,
     stopPlaying,
     showItemNow,
     setPlaying,

--- a/clock/src/controller/asset/team/TeamAssetController.spec.tsx
+++ b/clock/src/controller/asset/team/TeamAssetController.spec.tsx
@@ -231,7 +231,7 @@ function setupMocks(overrides?: {
   const mockSetRoster = vi.fn();
   const mockShowItemNow = vi.fn();
   const mockEditPlayer = vi.fn();
-  const mockPlayQueue = vi.fn();
+  const mockActivateQueue = vi.fn();
   const mockCreateQueue = vi
     .fn<(name: string) => string>()
     .mockReturnValue("new-queue-id");
@@ -254,7 +254,7 @@ function setupMocks(overrides?: {
     createQueue: mockCreateQueue,
     deleteQueue: mockDeleteQueue,
     addItemsToQueue: mockAddItemsToQueue,
-    playQueue: mockPlayQueue,
+    activateQueue: mockActivateQueue,
   } as unknown as ReturnType<typeof useController>);
 
   mockedUseRemoteSettings.mockReturnValue({
@@ -280,7 +280,7 @@ function setupMocks(overrides?: {
     mockCreateQueue,
     mockDeleteQueue,
     mockAddItemsToQueue,
-    mockPlayQueue,
+    mockActivateQueue,
   };
 }
 
@@ -595,7 +595,7 @@ describe("TeamAssetController", () => {
       const {
         mockCreateQueue,
         mockAddItemsToQueue,
-        mockPlayQueue,
+        mockActivateQueue,
         mockEditPlayer,
       } = setupMocks({
         roster: mockRoster,
@@ -645,7 +645,7 @@ describe("TeamAssetController", () => {
           subOut: subOutAsset,
         }),
       ]);
-      expect(mockPlayQueue).toHaveBeenCalledWith("new-queue-id");
+      expect(mockActivateQueue).toHaveBeenCalledWith("new-queue-id");
       expect(mockEditPlayer).toHaveBeenCalled();
     });
 

--- a/clock/src/controller/asset/team/TeamAssetController.spec.tsx
+++ b/clock/src/controller/asset/team/TeamAssetController.spec.tsx
@@ -231,6 +231,7 @@ function setupMocks(overrides?: {
   const mockSetRoster = vi.fn();
   const mockShowItemNow = vi.fn();
   const mockEditPlayer = vi.fn();
+  const mockPlayQueue = vi.fn();
   const mockCreateQueue = vi
     .fn<(name: string) => string>()
     .mockReturnValue("new-queue-id");
@@ -253,6 +254,7 @@ function setupMocks(overrides?: {
     createQueue: mockCreateQueue,
     deleteQueue: mockDeleteQueue,
     addItemsToQueue: mockAddItemsToQueue,
+    playQueue: mockPlayQueue,
   } as unknown as ReturnType<typeof useController>);
 
   mockedUseRemoteSettings.mockReturnValue({
@@ -278,6 +280,7 @@ function setupMocks(overrides?: {
     mockCreateQueue,
     mockDeleteQueue,
     mockAddItemsToQueue,
+    mockPlayQueue,
   };
 }
 
@@ -589,7 +592,12 @@ describe("TeamAssetController", () => {
     });
 
     it("completes substitution flow when both players selected", async () => {
-      const { mockShowItemNow, mockEditPlayer } = setupMocks({
+      const {
+        mockCreateQueue,
+        mockAddItemsToQueue,
+        mockPlayQueue,
+        mockEditPlayer,
+      } = setupMocks({
         roster: mockRoster,
       });
 
@@ -625,23 +633,24 @@ describe("TeamAssetController", () => {
       fireEvent.click(screen.getByTestId("modal-player-Siggi Bekkur"));
 
       await waitFor(() => {
-        expect(mockShowItemNow).toHaveBeenCalled();
+        expect(mockCreateQueue).toHaveBeenCalledWith("Skiptingar", {
+          cycle: false,
+        });
       });
 
-      expect(mockEditPlayer).toHaveBeenCalled();
-
-      const callArgs = mockShowItemNow.mock.calls[0]!;
-      expect(callArgs[0]).toEqual(
+      expect(mockAddItemsToQueue).toHaveBeenCalledWith("new-queue-id", [
         expect.objectContaining({
           type: "SUB",
           subIn: subInAsset,
           subOut: subOutAsset,
         }),
-      );
+      ]);
+      expect(mockPlayQueue).toHaveBeenCalledWith("new-queue-id");
+      expect(mockEditPlayer).toHaveBeenCalled();
     });
 
-    it("does not call showItemNow if getPlayerAssetObject returns null for subIn", async () => {
-      const { mockShowItemNow } = setupMocks({ roster: mockRoster });
+    it("does not add to queue if getPlayerAssetObject returns null for subIn", async () => {
+      const { mockAddItemsToQueue } = setupMocks({ roster: mockRoster });
 
       mockedGetPlayerAssetObject.mockResolvedValue(null);
 
@@ -656,7 +665,7 @@ describe("TeamAssetController", () => {
         expect(mockedGetPlayerAssetObject).toHaveBeenCalled();
       });
 
-      expect(mockShowItemNow).not.toHaveBeenCalled();
+      expect(mockAddItemsToQueue).not.toHaveBeenCalled();
     });
   });
 

--- a/clock/src/controller/asset/team/TeamAssetController.tsx
+++ b/clock/src/controller/asset/team/TeamAssetController.tsx
@@ -42,6 +42,7 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
     deleteQueue,
     addItemsToQueue,
     showItemNow,
+    playQueue,
   } = useController();
   const { roster } = controller;
   const { screens } = useListeners();
@@ -91,6 +92,19 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
     setSelectMOTM(false);
     setModalMode(null);
     setSubOffPlayer(null);
+  };
+
+  const SUBS_QUEUE_NAME = "Skiptingar";
+
+  const addSubToQueue = (asset: Asset): void => {
+    const existingQueue = Object.values(controller.queues).find(
+      (q) => q.name === SUBS_QUEUE_NAME,
+    );
+    const queueId = existingQueue
+      ? existingQueue.id
+      : createQueue(SUBS_QUEUE_NAME, { cycle: false });
+    addItemsToQueue(queueId, [asset]);
+    playQueue(queueId);
   };
 
   const addTeamToQueue = async (side: "home" | "away"): Promise<void> => {
@@ -164,7 +178,7 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
           isHome && homeRevealBg
             ? { ...subOutObj, background: homeRevealBg }
             : subOutObj;
-        showItemNow({
+        addSubToQueue({
           type: assetTypes.SUB,
           subIn: finalSubIn,
           subOut: finalSubOut,
@@ -283,7 +297,7 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
         isHome && homeRevealBg
           ? { ...subOutObj, background: homeRevealBg }
           : subOutObj;
-      showItemNow({
+      addSubToQueue({
         type: assetTypes.SUB,
         subIn: finalSubIn,
         subOut: finalSubOut,

--- a/clock/src/controller/asset/team/TeamAssetController.tsx
+++ b/clock/src/controller/asset/team/TeamAssetController.tsx
@@ -42,7 +42,7 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
     deleteQueue,
     addItemsToQueue,
     showItemNow,
-    playQueue,
+    activateQueue,
   } = useController();
   const { roster } = controller;
   const { screens } = useListeners();
@@ -104,7 +104,7 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
       ? existingQueue.id
       : createQueue(SUBS_QUEUE_NAME, { cycle: false });
     addItemsToQueue(queueId, [asset]);
-    playQueue(queueId);
+    activateQueue(queueId);
   };
 
   const addTeamToQueue = async (side: "home" | "away"): Promise<void> => {


### PR DESCRIPTION
## Summary

- Substitutions now queue into a **"Skiptingar"** queue instead of displaying immediately via `showItemNow`
- Queue is auto-created (with `cycle: false`) on first substitution if it doesn't exist
- Queue becomes active immediately after creation, operator advances through subs via playback controls or spacebar
- Non-substitution flows (goals, team display, etc.) remain unchanged

Closes #181

## Screenshots

### Teams view — substitution controls
![Teams view](https://staging-klukka.irdn.is/pr-images/181-screenshot-teams-view-1778316187.png)

### Substitution modal (toggle off / on)
![Sub modal off](https://staging-klukka.irdn.is/pr-images/181-screenshot-sub-modal-off-1778316187.png)
![Sub modal on](https://staging-klukka.irdn.is/pr-images/181-screenshot-sub-modal-on-1778316187.png)

### Skiptingar queue with items
![Queue with items](https://staging-klukka.irdn.is/pr-images/181-screenshot-skiptingar-queue-with-items-1778316187.png)

### Queue board showing Skiptingar
![Queue board](https://staging-klukka.irdn.is/pr-images/181-screenshot-skiptingar-queue-1778316187.png)

### Playback bar showing active Skiptingar queue
![Playback bar](https://staging-klukka.irdn.is/pr-images/181-screenshot-skiptingar-playback-1778316187.png)

## Staging

Deployed to https://staging-klukka.irdn.is

## Testing

All 45 tests pass. Updated tests to verify queue creation + item addition instead of `showItemNow`.