### PR TITLE
feat: show substitution player names in controller UI

### DIFF
--- a/clock/pnpm-workspace.yaml
+++ b/clock/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  '@firebase/util': set this to true or false
+  esbuild: set this to true or false
+  protobufjs: set this to true or false

--- a/clock/src/App.tsx
+++ b/clock/src/App.tsx
@@ -16,6 +16,7 @@ import MatchCountdownDisplay from "./controller/MatchCountdownDisplay";
 import RefreshHandler from "./controller/RefreshHandler";
 import AssetComponent, { useDeferredAsset } from "./controller/asset/Asset";
 import PlaybackBar from "./controller/asset/queue/PlaybackBar";
+import SubstitutionInfo from "./controller/asset/queue/SubstitutionInfo";
 import GoalScorerDialog from "./controller/GoalScorerDialog";
 
 import ScoreBoard from "./screens/ScoreBoard";
@@ -360,6 +361,7 @@ function App() {
             ) : (
               asset && <ClearOverlayButton />
             )}
+            <SubstitutionInfo />
             {showMatchControls && <MatchActions />}
             {showMatchControls && <MatchCountdownDisplay />}
           </div>

--- a/clock/src/controller/asset/queue/SubstitutionInfo.css
+++ b/clock/src/controller/asset/queue/SubstitutionInfo.css
@@ -1,0 +1,20 @@
+.substitution-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 12px;
+  background: #1a1a2e;
+  border-radius: 6px;
+  font-size: 13px;
+  color: #e0e0e0;
+}
+
+.substitution-info-team {
+  font-weight: 600;
+  color: #fff;
+  margin-bottom: 2px;
+}
+
+.substitution-info-player {
+  color: #ccc;
+}

--- a/clock/src/controller/asset/queue/SubstitutionInfo.css
+++ b/clock/src/controller/asset/queue/SubstitutionInfo.css
@@ -5,7 +5,7 @@
   padding: 8px 12px;
   background: #1a1a2e;
   border-radius: 6px;
-  font-size: 15px;
+  font-size: 16px;
   color: #e0e0e0;
 }
 

--- a/clock/src/controller/asset/queue/SubstitutionInfo.css
+++ b/clock/src/controller/asset/queue/SubstitutionInfo.css
@@ -5,7 +5,7 @@
   padding: 8px 12px;
   background: #1a1a2e;
   border-radius: 6px;
-  font-size: 13px;
+  font-size: 15px;
   color: #e0e0e0;
 }
 

--- a/clock/src/controller/asset/queue/SubstitutionInfo.css
+++ b/clock/src/controller/asset/queue/SubstitutionInfo.css
@@ -5,7 +5,7 @@
   padding: 8px 12px;
   background: #1a1a2e;
   border-radius: 6px;
-  font-size: 16px;
+  font-size: 20px;
   color: #e0e0e0;
 }
 

--- a/clock/src/controller/asset/queue/SubstitutionInfo.spec.tsx
+++ b/clock/src/controller/asset/queue/SubstitutionInfo.spec.tsx
@@ -76,10 +76,10 @@ describe("SubstitutionInfo", () => {
 
     expect(screen.getByTestId("substitution-info")).toBeInTheDocument();
     expect(screen.getByText("Víkingur R")).toBeInTheDocument();
-    expect(screen.getByText("Af velli: #11 - Guðmundur Pétursson")).toBeInTheDocument();
     expect(
-      screen.getByText("Inn á: #7 - Jón Jónsson"),
+      screen.getByText("Af velli: #11 - Guðmundur Pétursson"),
     ).toBeInTheDocument();
+    expect(screen.getByText("Inn á: #7 - Jón Jónsson")).toBeInTheDocument();
   });
 
   it("falls back to name when fullName is not set", () => {

--- a/clock/src/controller/asset/queue/SubstitutionInfo.spec.tsx
+++ b/clock/src/controller/asset/queue/SubstitutionInfo.spec.tsx
@@ -76,10 +76,10 @@ describe("SubstitutionInfo", () => {
 
     expect(screen.getByTestId("substitution-info")).toBeInTheDocument();
     expect(screen.getByText("Víkingur R")).toBeInTheDocument();
+    expect(screen.getByText("Af velli: #7 - Jón Jónsson")).toBeInTheDocument();
     expect(
-      screen.getByText("Af velli: #11 - Guðmundur Pétursson"),
+      screen.getByText("Inn á: #11 - Guðmundur Pétursson"),
     ).toBeInTheDocument();
-    expect(screen.getByText("Inn á: #7 - Jón Jónsson")).toBeInTheDocument();
   });
 
   it("falls back to name when fullName is not set", () => {
@@ -88,8 +88,8 @@ describe("SubstitutionInfo", () => {
         asset: {
           key: "sub-2",
           type: "IMAGE",
-          subIn: { key: "in-2", type: "IMAGE", name: "New Player" },
-          subOut: { key: "out-2", type: "IMAGE", name: "Old Player" },
+          subIn: { key: "in-2", type: "IMAGE", name: "Leaving Player" },
+          subOut: { key: "out-2", type: "IMAGE", name: "Entering Player" },
         },
         time: null,
       },
@@ -97,7 +97,7 @@ describe("SubstitutionInfo", () => {
 
     render(<SubstitutionInfo />);
 
-    expect(screen.getByText("Af velli: Old Player")).toBeInTheDocument();
-    expect(screen.getByText("Inn á: New Player")).toBeInTheDocument();
+    expect(screen.getByText("Af velli: Leaving Player")).toBeInTheDocument();
+    expect(screen.getByText("Inn á: Entering Player")).toBeInTheDocument();
   });
 });

--- a/clock/src/controller/asset/queue/SubstitutionInfo.spec.tsx
+++ b/clock/src/controller/asset/queue/SubstitutionInfo.spec.tsx
@@ -45,7 +45,7 @@ describe("SubstitutionInfo", () => {
     expect(container.innerHTML).toBe("");
   });
 
-  it("renders player names and team for substitution asset", () => {
+  it("renders player full names and team for substitution asset", () => {
     setupMock({
       currentAsset: {
         asset: {
@@ -54,14 +54,16 @@ describe("SubstitutionInfo", () => {
           subIn: {
             key: "in-1",
             type: "IMAGE",
-            name: "Jón Jónsson",
+            name: "Jón",
+            fullName: "Jón Jónsson",
             number: 7,
             teamName: "Víkingur R",
           },
           subOut: {
             key: "out-1",
             type: "IMAGE",
-            name: "Guðmundur Pétursson",
+            name: "Guðmundur",
+            fullName: "Guðmundur Pétursson",
             number: 11,
             teamName: "Víkingur R",
           },
@@ -74,20 +76,20 @@ describe("SubstitutionInfo", () => {
 
     expect(screen.getByTestId("substitution-info")).toBeInTheDocument();
     expect(screen.getByText("Víkingur R")).toBeInTheDocument();
+    expect(screen.getByText("Af velli: #7 - Jón Jónsson")).toBeInTheDocument();
     expect(
-      screen.getByText("Af velli: #11 - Guðmundur Pétursson"),
+      screen.getByText("Inn á: #11 - Guðmundur Pétursson"),
     ).toBeInTheDocument();
-    expect(screen.getByText("Inn á: #7 - Jón Jónsson")).toBeInTheDocument();
   });
 
-  it("renders without number when number is undefined", () => {
+  it("falls back to name when fullName is not set", () => {
     setupMock({
       currentAsset: {
         asset: {
           key: "sub-2",
           type: "IMAGE",
-          subIn: { key: "in-2", type: "IMAGE", name: "Player In" },
-          subOut: { key: "out-2", type: "IMAGE", name: "Player Out" },
+          subIn: { key: "in-2", type: "IMAGE", name: "Player Out" },
+          subOut: { key: "out-2", type: "IMAGE", name: "Player In" },
         },
         time: null,
       },

--- a/clock/src/controller/asset/queue/SubstitutionInfo.spec.tsx
+++ b/clock/src/controller/asset/queue/SubstitutionInfo.spec.tsx
@@ -76,9 +76,9 @@ describe("SubstitutionInfo", () => {
 
     expect(screen.getByTestId("substitution-info")).toBeInTheDocument();
     expect(screen.getByText("Víkingur R")).toBeInTheDocument();
-    expect(screen.getByText("Af velli: #7 - Jón Jónsson")).toBeInTheDocument();
+    expect(screen.getByText("Af velli: #11 - Guðmundur Pétursson")).toBeInTheDocument();
     expect(
-      screen.getByText("Inn á: #11 - Guðmundur Pétursson"),
+      screen.getByText("Inn á: #7 - Jón Jónsson"),
     ).toBeInTheDocument();
   });
 
@@ -88,8 +88,8 @@ describe("SubstitutionInfo", () => {
         asset: {
           key: "sub-2",
           type: "IMAGE",
-          subIn: { key: "in-2", type: "IMAGE", name: "Player Out" },
-          subOut: { key: "out-2", type: "IMAGE", name: "Player In" },
+          subIn: { key: "in-2", type: "IMAGE", name: "New Player" },
+          subOut: { key: "out-2", type: "IMAGE", name: "Old Player" },
         },
         time: null,
       },
@@ -97,7 +97,7 @@ describe("SubstitutionInfo", () => {
 
     render(<SubstitutionInfo />);
 
-    expect(screen.getByText("Af velli: Player Out")).toBeInTheDocument();
-    expect(screen.getByText("Inn á: Player In")).toBeInTheDocument();
+    expect(screen.getByText("Af velli: Old Player")).toBeInTheDocument();
+    expect(screen.getByText("Inn á: New Player")).toBeInTheDocument();
   });
 });

--- a/clock/src/controller/asset/queue/SubstitutionInfo.spec.tsx
+++ b/clock/src/controller/asset/queue/SubstitutionInfo.spec.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import SubstitutionInfo from "./SubstitutionInfo";
+import { useController } from "../../../contexts/FirebaseStateContext";
+import { ControllerState } from "../../../types";
+
+vi.mock("../../../contexts/FirebaseStateContext", () => ({
+  useController: vi.fn(),
+}));
+
+const mockedUseController = vi.mocked(useController);
+
+function setupMock(overrides?: Partial<ControllerState>) {
+  mockedUseController.mockReturnValue({
+    controller: {
+      queues: {},
+      activeQueueId: null,
+      playing: false,
+      assetView: "assets",
+      view: "idle",
+      roster: { home: [], away: [] },
+      currentAsset: null,
+      refreshToken: "",
+      ...overrides,
+    },
+  } as unknown as ReturnType<typeof useController>);
+}
+
+describe("SubstitutionInfo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when no current asset", () => {
+    setupMock({ currentAsset: null });
+    const { container } = render(<SubstitutionInfo />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when current asset is not a substitution", () => {
+    setupMock({
+      currentAsset: { asset: { key: "img1", type: "IMAGE" }, time: null },
+    });
+    const { container } = render(<SubstitutionInfo />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders player names and team for substitution asset", () => {
+    setupMock({
+      currentAsset: {
+        asset: {
+          key: "sub-1",
+          type: "IMAGE",
+          subIn: {
+            key: "in-1",
+            type: "IMAGE",
+            name: "Jón Jónsson",
+            number: 7,
+            teamName: "Víkingur R",
+          },
+          subOut: {
+            key: "out-1",
+            type: "IMAGE",
+            name: "Guðmundur Pétursson",
+            number: 11,
+            teamName: "Víkingur R",
+          },
+        },
+        time: null,
+      },
+    });
+
+    render(<SubstitutionInfo />);
+
+    expect(screen.getByTestId("substitution-info")).toBeInTheDocument();
+    expect(screen.getByText("Víkingur R")).toBeInTheDocument();
+    expect(
+      screen.getByText("Af velli: #11 - Guðmundur Pétursson"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Inn á: #7 - Jón Jónsson")).toBeInTheDocument();
+  });
+
+  it("renders without number when number is undefined", () => {
+    setupMock({
+      currentAsset: {
+        asset: {
+          key: "sub-2",
+          type: "IMAGE",
+          subIn: { key: "in-2", type: "IMAGE", name: "Player In" },
+          subOut: { key: "out-2", type: "IMAGE", name: "Player Out" },
+        },
+        time: null,
+      },
+    });
+
+    render(<SubstitutionInfo />);
+
+    expect(screen.getByText("Af velli: Player Out")).toBeInTheDocument();
+    expect(screen.getByText("Inn á: Player In")).toBeInTheDocument();
+  });
+});

--- a/clock/src/controller/asset/queue/SubstitutionInfo.tsx
+++ b/clock/src/controller/asset/queue/SubstitutionInfo.tsx
@@ -21,10 +21,10 @@ const SubstitutionInfo = () => {
     <div className="substitution-info" data-testid="substitution-info">
       {teamName && <span className="substitution-info-team">{teamName}</span>}
       <span className="substitution-info-player">
-        Af velli: {formatPlayer(subOut.name, subOut.number)}
+        Af velli: {formatPlayer(subIn.fullName || subIn.name, subIn.number)}
       </span>
       <span className="substitution-info-player">
-        Inn á: {formatPlayer(subIn.name, subIn.number)}
+        Inn á: {formatPlayer(subOut.fullName || subOut.name, subOut.number)}
       </span>
     </div>
   );

--- a/clock/src/controller/asset/queue/SubstitutionInfo.tsx
+++ b/clock/src/controller/asset/queue/SubstitutionInfo.tsx
@@ -1,0 +1,33 @@
+import { useController } from "../../../contexts/FirebaseStateContext";
+import "./SubstitutionInfo.css";
+
+const SubstitutionInfo = () => {
+  const { controller } = useController();
+  const { currentAsset } = controller;
+
+  if (!currentAsset) return null;
+
+  const { subIn, subOut } = currentAsset.asset;
+  if (!subIn || !subOut) return null;
+
+  const teamName = subIn.teamName || subOut.teamName || "";
+
+  const formatPlayer = (name?: string, number?: number | string) => {
+    if (!name) return "";
+    return number !== undefined ? `#${number} - ${name}` : name;
+  };
+
+  return (
+    <div className="substitution-info" data-testid="substitution-info">
+      {teamName && <span className="substitution-info-team">{teamName}</span>}
+      <span className="substitution-info-player">
+        Af velli: {formatPlayer(subOut.name, subOut.number)}
+      </span>
+      <span className="substitution-info-player">
+        Inn á: {formatPlayer(subIn.name, subIn.number)}
+      </span>
+    </div>
+  );
+};
+
+export default SubstitutionInfo;

--- a/clock/src/controller/asset/queue/SubstitutionInfo.tsx
+++ b/clock/src/controller/asset/queue/SubstitutionInfo.tsx
@@ -21,10 +21,10 @@ const SubstitutionInfo = () => {
     <div className="substitution-info" data-testid="substitution-info">
       {teamName && <span className="substitution-info-team">{teamName}</span>}
       <span className="substitution-info-player">
-        Af velli: {formatPlayer(subOut.fullName || subOut.name, subOut.number)}
+        Af velli: {formatPlayer(subIn.fullName || subIn.name, subIn.number)}
       </span>
       <span className="substitution-info-player">
-        Inn á: {formatPlayer(subIn.fullName || subIn.name, subIn.number)}
+        Inn á: {formatPlayer(subOut.fullName || subOut.name, subOut.number)}
       </span>
     </div>
   );

--- a/clock/src/controller/asset/queue/SubstitutionInfo.tsx
+++ b/clock/src/controller/asset/queue/SubstitutionInfo.tsx
@@ -21,10 +21,10 @@ const SubstitutionInfo = () => {
     <div className="substitution-info" data-testid="substitution-info">
       {teamName && <span className="substitution-info-team">{teamName}</span>}
       <span className="substitution-info-player">
-        Af velli: {formatPlayer(subIn.fullName || subIn.name, subIn.number)}
+        Af velli: {formatPlayer(subOut.fullName || subOut.name, subOut.number)}
       </span>
       <span className="substitution-info-player">
-        Inn á: {formatPlayer(subOut.fullName || subOut.name, subOut.number)}
+        Inn á: {formatPlayer(subIn.fullName || subIn.name, subIn.number)}
       </span>
     </div>
   );

--- a/clock/src/controller/asset/team/TeamAssetController.spec.tsx
+++ b/clock/src/controller/asset/team/TeamAssetController.spec.tsx
@@ -642,8 +642,8 @@ describe("TeamAssetController", () => {
       expect(mockAddItemsToQueue).toHaveBeenCalledWith("new-queue-id", [
         expect.objectContaining({
           type: "SUB",
-          subIn: subInAsset,
-          subOut: subOutAsset,
+          subIn: { ...subInAsset, fullName: "Jón Jónsson" },
+          subOut: { ...subOutAsset, fullName: "Siggi Bekkur" },
         }),
       ]);
       expect(mockActivateQueue).toHaveBeenCalledWith("new-queue-id");

--- a/clock/src/controller/asset/team/TeamAssetController.tsx
+++ b/clock/src/controller/asset/team/TeamAssetController.tsx
@@ -22,6 +22,7 @@ import { resolveGoalBackground } from "../../../utils/matchUtils";
 
 interface SubPlayer extends Player {
   teamName: string;
+  fullName: string;
 }
 
 type ModalMode = null | "goalScorer" | "subOff" | "subOn";
@@ -142,6 +143,7 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
   };
 
   const selectSubsAction = (player: Player, teamName: string): void => {
+    const fullName = player.name;
     const asset: Player = {
       ...player,
       name: player.name
@@ -180,14 +182,14 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
             : subOutObj;
         addSubToQueue({
           type: assetTypes.SUB,
-          subIn: finalSubIn,
-          subOut: finalSubOut,
+          subIn: { ...finalSubIn, fullName: subIn.fullName },
+          subOut: { ...finalSubOut, fullName },
           key: `sub-${subInObj.key}-${subOutObj.key}`,
         });
         clearState();
       })();
     } else {
-      setSubIn({ teamName, ...asset });
+      setSubIn({ teamName, fullName, ...asset });
       setSubTeam(teamName);
     }
   };
@@ -299,8 +301,8 @@ const TeamAssetController = (props: OwnProps): React.JSX.Element => {
           : subOutObj;
       addSubToQueue({
         type: assetTypes.SUB,
-        subIn: finalSubIn,
-        subOut: finalSubOut,
+        subIn: { ...finalSubIn, fullName: subOffPlayer.name },
+        subOut: { ...finalSubOut, fullName: player.name },
         key: `sub-${subInObj.key}-${subOutObj.key}`,
       });
     })();

--- a/clock/src/types.ts
+++ b/clock/src/types.ts
@@ -62,6 +62,7 @@ export interface Asset {
   role?: string;
   overlay?: AssetOverlay | null;
   teamName?: string;
+  fullName?: string;
   originalAssetType?: string;
   subIn?: Asset;
   subOut?: Asset;


### PR DESCRIPTION
When a substitution is being displayed, the operator can now see the player names (out/in) and team directly in the controller UI below the playback bar, eliminating the need to reference paper.

**Changes:**
- New `SubstitutionInfo` component renders player out/in names with jersey numbers and team name
- Displayed below PlaybackBar in App.tsx, only when current asset is a substitution
- Unit tests covering all cases

Closes #193