### PR TITLE
feat: add configurable red card position to theme system

### DIFF
--- a/clock/e2e/idle-visual-editor.spec.ts
+++ b/clock/e2e/idle-visual-editor.spec.ts
@@ -190,8 +190,8 @@ test.describe("Idle visual editor", () => {
     const scoreboardCanvas = page.locator(".visual-canvas");
     await expect(scoreboardCanvas).toBeVisible({ timeout: 5000 });
 
-    // Scoreboard editor has 7 elements (home-logo, away-logo, clock, home-score, away-score, injury-time, ad)
-    await expect(page.locator("[data-element-id]")).toHaveCount(7);
+    // Scoreboard editor has 8 elements (home-logo, away-logo, clock, home-score, away-score, injury-time, ad, red-card)
+    await expect(page.locator("[data-element-id]")).toHaveCount(8);
 
     // Switch to idle visual tab
     await switchToIdleVisualTab(page);

--- a/clock/src/constants.ts
+++ b/clock/src/constants.ts
@@ -170,6 +170,8 @@ export const DEFAULT_THEME: ThemeConfig = {
 
   // Red cards
   redCardColor: "#e60000",
+  redCardTop: "58%",
+  redCardLeft: "6%",
 
   // Penalty boxes
   penaltyBg: "black",
@@ -250,6 +252,8 @@ export const THEME_PRESETS: Record<string, ThemeConfig> = {
     penaltyColor: "#fff",
     penaltyBorder: "2px solid #ff2030",
     redCardColor: "#ff1a1a",
+    redCardTop: "58%",
+    redCardLeft: "6%",
     timeoutColor: "#ff2030",
     idleTextColor: "#ffcccc",
     idleTextFontSize: "44px",
@@ -287,6 +291,8 @@ export const THEME_PRESETS: Record<string, ThemeConfig> = {
     penaltyColor: "#1a0000",
     penaltyBorder: "2px solid #c7000f",
     redCardColor: "#c7000f",
+    redCardTop: "58%",
+    redCardLeft: "6%",
     timeoutColor: "#c7000f",
     idleTextColor: "#1a0000",
     idleTextFontSize: "38px",
@@ -369,6 +375,8 @@ export const THEME_PRESETS: Record<string, ThemeConfig> = {
     penaltyColor: "#00e5ff",
     penaltyBorder: "2px solid #0080ff",
     redCardColor: "#ff2040",
+    redCardTop: "58%",
+    redCardLeft: "6%",
     timeoutColor: "#0080ff",
     idleTextColor: "#80d0ff",
     idleTextFontSize: "36px",
@@ -410,6 +418,8 @@ export const THEME_PRESETS: Record<string, ThemeConfig> = {
     penaltyColor: "#33ff33",
     penaltyBorder: "2px solid #33ff33",
     redCardColor: "#ff3333",
+    redCardTop: "58%",
+    redCardLeft: "6%",
     timeoutColor: "#33ff33",
     idleTextColor: "#33ff33",
     idleTextFontSize: "32px",

--- a/clock/src/controller/theme/ThemeEditor.tsx
+++ b/clock/src/controller/theme/ThemeEditor.tsx
@@ -543,6 +543,18 @@ const ThemeEditorPanels = ({
         defaultValue={DEFAULT_THEME.redCardColor}
         onChange={(v) => onFieldChange("redCardColor", v)}
       />
+      <PercentField
+        label="Rautt spjald ofan"
+        value={effective.redCardTop}
+        defaultValue={DEFAULT_THEME.redCardTop}
+        onChange={(v) => onFieldChange("redCardTop", v)}
+      />
+      <PercentField
+        label="Rautt spjald vinstri"
+        value={effective.redCardLeft}
+        defaultValue={DEFAULT_THEME.redCardLeft}
+        onChange={(v) => onFieldChange("redCardLeft", v)}
+      />
       <ColorField
         label="Vítabox bakgr."
         value={effective.penaltyBg}

--- a/clock/src/controller/theme/VisualThemeEditor.tsx
+++ b/clock/src/controller/theme/VisualThemeEditor.tsx
@@ -148,6 +148,20 @@ const ELEMENTS: ElementDef[] = [
     colorFields: { bg: "adTop", text: "adTop" },
     displayText: "AD",
   },
+  {
+    id: "red-card",
+    label: "Rautt spjald",
+    left: (t) => t.redCardLeft,
+    top: (t) => t.redCardTop,
+    width: () => "4%",
+    height: () => "6%",
+    bg: (t) => t.redCardColor,
+    color: () => "#fff",
+    border: () => "1px solid rgba(0,0,0,0.3)",
+    dragFields: { top: "redCardTop", left: "redCardLeft" },
+    colorFields: { bg: "redCardColor", text: "redCardColor" },
+    displayText: "",
+  },
 ];
 
 /** Sanitize a URL for use inside CSS url() by escaping breakout characters */

--- a/clock/src/hooks/useThemeCssVars.ts
+++ b/clock/src/hooks/useThemeCssVars.ts
@@ -52,6 +52,8 @@ export const themeToCssVars = (theme: ThemeConfig): Record<string, string> => ({
 
   // Red cards
   "--theme-red-card-color": theme.redCardColor,
+  "--theme-red-card-top": theme.redCardTop,
+  "--theme-red-card-left": theme.redCardLeft,
 
   // Penalty boxes
   "--theme-penalty-bg": theme.penaltyBg,

--- a/clock/src/match/RedCard.css
+++ b/clock/src/match/RedCard.css
@@ -1,13 +1,13 @@
 .team .red-cards {
   position: absolute;
-  top: 58%;
+  top: var(--theme-red-card-top, 58%);
   z-index: 9999;
   height: 34%;
   width: 25%;
 }
 
 .team.home .red-cards {
-  left: 6%;
+  left: var(--theme-red-card-left, 6%);
 }
 
 .team.home .red-card {
@@ -16,7 +16,7 @@
 }
 
 .team.away .red-cards {
-  right: 6%;
+  right: var(--theme-red-card-left, 6%);
 }
 
 .team.away .red-card {

--- a/clock/src/types.ts
+++ b/clock/src/types.ts
@@ -171,6 +171,8 @@ export interface ThemeConfig {
 
   // Red cards
   redCardColor: string;
+  redCardTop: string;
+  redCardLeft: string;
 
   // Penalty boxes (handball)
   penaltyBg: string;


### PR DESCRIPTION
Add `redCardTop` and `redCardLeft` properties to ThemeConfig, allowing red card indicator position to be configured via the visual theme editor. Only the home (left) position is editable in the visual editor; the away (right) card mirrors with the same top and same horizontal offset from its respective edge.

Changes:
- Added `redCardTop` and `redCardLeft` to `ThemeConfig` interface
- Added CSS vars `--theme-red-card-top` and `--theme-red-card-left`
- Updated `RedCard.css` to use theme vars (home=left, away=right with same offset)
- Added draggable red card element in visual theme editor
- Updated all preset themes with default values

Closes #194