### PR TITLE
fix: support custom override teams in selector

### DIFF
--- a/clock/AGENTS.md
+++ b/clock/AGENTS.md
@@ -648,6 +648,10 @@ const lookupClubId = (name: string): string =>
 - **`"-1"`**: Teams not found in KSI (combined teams, foreign clubs, national teams). Still selectable in the UI but won't match API data.
 - **`"0"`**: Unknown/unrecognized team name (fallback when lookup fails).
 
+### Custom Team Overrides In Selectors
+
+Firebase `clubOverrides` entries with `isOverride: false` act as fully custom teams. They are merged into the `TeamSelector.tsx` dropdown alongside bundled `club-ids.ts` teams, and `updateMatch()` resolves their configured `clubId` from Firebase before falling back to bundled IDs. This allows custom teams like `Kjánaprik` to be selected in Stillingar and keep `clubId: "-1"` until a real KSI ID is added later.
+
 ### Key Files in the Pipeline
 
 | File                                            | Role                                                                               |

--- a/clock/src/contexts/FirebaseStateContext.spec.tsx
+++ b/clock/src/contexts/FirebaseStateContext.spec.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, act } from "@testing-library/react";
+import { onValue, ref } from "firebase/database";
 import {
   FirebaseStateProvider,
   useMatch,
@@ -74,6 +75,24 @@ const TestViewConsumer = ({
 describe("FirebaseStateContext", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+
+    vi.mocked(ref).mockImplementation((_, path) => path as never);
+
+    vi.mocked(onValue).mockImplementation((reference, callback) => {
+      const path = String(reference);
+
+      if (path.includes("clubOverrides")) {
+        callback({
+          val: () => null,
+        } as never);
+      } else {
+        callback({
+          val: () => null,
+        } as never);
+      }
+
+      return vi.fn();
+    });
   });
 
   describe("empty listenPrefix protection", () => {
@@ -847,6 +866,100 @@ describe("FirebaseStateContext", () => {
         "test-location",
         "match",
         { homeTeam: "Víkingur R", homeTeamId: 2492, ksiMatchId: null },
+      );
+    });
+
+    it("looks up custom team IDs from club overrides", () => {
+      vi.mocked(onValue).mockImplementation((reference, callback) => {
+        const path = String(reference);
+
+        callback({
+          val: () =>
+            path.includes("clubOverrides")
+              ? {
+                  customTeam: {
+                    name: "Kjánaprik",
+                    clubId: "-1",
+                    logoUrl: "https://example.com/kjanaprik.png",
+                    isOverride: false,
+                  },
+                }
+              : null,
+        } as never);
+
+        return vi.fn();
+      });
+
+      let matchApi: ReturnType<typeof useMatch> | null = null;
+      render(
+        <FirebaseStateProvider
+          listenPrefix="test-location"
+          isAuthenticated={true}
+          screenKey={null}
+        >
+          <TestMatchConsumer
+            onMount={(api) => {
+              matchApi = api;
+            }}
+          />
+        </FirebaseStateProvider>,
+      );
+
+      act(() => {
+        matchApi!.updateMatch({ homeTeam: "Kjánaprik" });
+      });
+
+      expect(firebaseDatabase.syncState).toHaveBeenCalledWith(
+        "test-location",
+        "match",
+        { homeTeam: "Kjánaprik", homeTeamId: -1, ksiMatchId: null },
+      );
+    });
+
+    it("normalizes typed custom team names with trailing dots to override canonical name", () => {
+      vi.mocked(onValue).mockImplementation((reference, callback) => {
+        const path = String(reference);
+
+        callback({
+          val: () =>
+            path.includes("clubOverrides")
+              ? {
+                  customTeam: {
+                    name: "Kjánaprik",
+                    clubId: "-1",
+                    logoUrl: "https://example.com/kjanaprik.png",
+                    isOverride: false,
+                  },
+                }
+              : null,
+        } as never);
+
+        return vi.fn();
+      });
+
+      let matchApi: ReturnType<typeof useMatch> | null = null;
+      render(
+        <FirebaseStateProvider
+          listenPrefix="test-location"
+          isAuthenticated={true}
+          screenKey={null}
+        >
+          <TestMatchConsumer
+            onMount={(api) => {
+              matchApi = api;
+            }}
+          />
+        </FirebaseStateProvider>,
+      );
+
+      act(() => {
+        matchApi!.updateMatch({ awayTeam: "Kjánaprik." });
+      });
+
+      expect(firebaseDatabase.syncState).toHaveBeenCalledWith(
+        "test-location",
+        "match",
+        { awayTeam: "Kjánaprik", awayTeamId: -1, ksiMatchId: null },
       );
     });
 

--- a/clock/src/contexts/FirebaseStateContext.tsx
+++ b/clock/src/contexts/FirebaseStateContext.tsx
@@ -45,6 +45,19 @@ import {
 
 const HALFTIME_DURATION_MS = 15 * 60 * 1000;
 
+const normalizeClubKey = (name: string): string => name.replace(/\.+$/, "");
+
+const findClubOverrideByName = (
+  overrides: Record<string, ClubOverride>,
+  name: string,
+): ClubOverride | undefined => {
+  const normalizedName = normalizeClubKey(name);
+
+  return Object.values(overrides).find(
+    (override) => normalizeClubKey(override.name) === normalizedName,
+  );
+};
+
 const defaultMatch: Match = {
   homeScore: 0,
   awayScore: 0,
@@ -594,13 +607,18 @@ export const FirebaseStateProvider: React.FC<FirebaseStateProviderProps> = ({
       const newState: Match = { ...prev, ...updates };
       const clubIdsMap = clubIds as Record<string, string>;
       const normalizeTeamName = (name: string): string => {
+        const override = findClubOverrideByName(clubOverridesRef.current, name);
+        if (override) return override.name;
         if (clubIdsMap[name]) return name;
-        const stripped = name.replace(/\.+$/, "");
+        const stripped = normalizeClubKey(name);
         if (clubIdsMap[stripped]) return stripped;
         return name;
       };
       const lookupClubId = (name: string): string =>
-        clubIdsMap[name] ?? clubIdsMap[name.replace(/\.+$/, "")] ?? "0";
+        findClubOverrideByName(clubOverridesRef.current, name)?.clubId ??
+        clubIdsMap[name] ??
+        clubIdsMap[normalizeClubKey(name)] ??
+        "0";
       if (newState.homeTeam) {
         newState.homeTeam = normalizeTeamName(newState.homeTeam);
       }

--- a/clock/src/controller/TeamSelector.spec.tsx
+++ b/clock/src/controller/TeamSelector.spec.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import TeamSelector from "./TeamSelector";
+
+vi.mock("../contexts/FirebaseStateContext", () => ({
+  useMatch: vi.fn(),
+  useClubOverrides: vi.fn(),
+}));
+
+import { useMatch, useClubOverrides } from "../contexts/FirebaseStateContext";
+
+const mockedUseMatch = vi.mocked(useMatch);
+const mockedUseClubOverrides = vi.mocked(useClubOverrides);
+
+describe("TeamSelector", () => {
+  const mockUpdateMatch = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockedUseMatch.mockReturnValue({
+      match: {
+        homeTeam: "",
+        awayTeam: "",
+      },
+      updateMatch: mockUpdateMatch,
+    } as unknown as ReturnType<typeof useMatch>);
+
+    mockedUseClubOverrides.mockReturnValue({
+      clubOverrides: {
+        customTeam: {
+          name: "Kjánaprik",
+          clubId: "-1",
+          logoUrl: "https://example.com/kjanaprik.png",
+          isOverride: false,
+        },
+      },
+      saveClubOverride: vi.fn(),
+      deleteClubOverride: vi.fn(),
+    });
+  });
+
+  it("renders custom override teams in the select options", () => {
+    render(<TeamSelector teamAttrName="homeTeam" />);
+
+    expect(
+      screen.getByRole("option", { name: "Kjánaprik" }),
+    ).toBeInTheDocument();
+  });
+
+  it("updates the selected team when choosing a custom override team", () => {
+    render(<TeamSelector teamAttrName="homeTeam" />);
+
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "Kjánaprik" },
+    });
+
+    expect(mockUpdateMatch).toHaveBeenCalledWith({ homeTeam: "Kjánaprik" });
+  });
+});

--- a/clock/src/controller/TeamSelector.tsx
+++ b/clock/src/controller/TeamSelector.tsx
@@ -1,7 +1,7 @@
 import clubIds from "../club-ids";
 
 import { Match, TwoMinPenalty } from "../types";
-import { useMatch } from "../contexts/FirebaseStateContext";
+import { useClubOverrides, useMatch } from "../contexts/FirebaseStateContext";
 
 const normalize = (string: string) =>
   string
@@ -39,6 +39,14 @@ interface TeamSelectorProps {
 
 const TeamSelector = ({ teamAttrName }: TeamSelectorProps) => {
   const { match, updateMatch } = useMatch();
+  const { clubOverrides } = useClubOverrides();
+
+  const teamOptions = [
+    ...new Set([
+      ...Object.keys(clubIds),
+      ...Object.values(clubOverrides).map((override) => override.name),
+    ]),
+  ].sort((v1, v2) => v1.localeCompare(v2, "is"));
 
   return (
     <div>
@@ -49,9 +57,8 @@ const TeamSelector = ({ teamAttrName }: TeamSelectorProps) => {
         }
       >
         <option value="">Veldu lið...</option>
-        {Object.keys(clubIds)
+        {teamOptions
           .filter((key) => filterOption(key, match[teamAttrName] as string))
-          .sort((v1, v2) => v1.localeCompare(v2))
           .map((key) => (
             <option value={key} key={key}>
               {key}


### PR DESCRIPTION
## Summary
- include Firebase custom club overrides in the Stillingar team selector
- resolve team IDs from custom overrides before falling back to bundled club IDs
- add tests for custom -1 teams like Kjánaprik

## Testing
- `cd clock && pnpm lint`
- `cd clock && pnpm vitest run src/controller/TeamSelector.spec.tsx src/contexts/FirebaseStateContext.spec.tsx`
